### PR TITLE
ci: migrate quality-assurance to shared netresearch/.github php-ci reusable

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -6,164 +6,72 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions: {}
+
 jobs:
   static-analysis:
     name: Static Analysis
-    runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        php-version: ['8.2', '8.3']
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: soap, libxml, mbstring
-          tools: composer:v2
-          coverage: none
-          
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-        
-      - name: Cache composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-          
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-        
-      - name: Run PHPStan
-        run: vendor/bin/phpstan analyse --no-progress
-        
-      - name: Run PHP_CodeSniffer
-        run: vendor/bin/phpcs
-        
-      - name: Run PHPMD
-        run: vendor/bin/phpmd src text phpmd.xml
-        
-        
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2","8.3"]'
+      extensions: "soap, libxml, mbstring"
+      coverage: "none"
+      phpstan-cmd: 'vendor/bin/phpstan analyse --no-progress --error-format=github && vendor/bin/phpcs && vendor/bin/phpmd src text phpmd.xml'
+      run-phpunit: false
+
   tests:
     name: Tests
-    runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        php-version: ['8.2', '8.3']
-        
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: soap, libxml, mbstring, xdebug
-          tools: composer:v2
-          coverage: xdebug
-          
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-        
-      - name: Cache composer dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
-          
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-        
-      - name: Run unit tests
-        run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
-        
-      - name: Run integration tests
-        run: vendor/bin/phpunit --testsuite=integration --no-coverage
-        continue-on-error: true
-        env:
-          USE_PRODUCTION_ENDPOINT: false
-          REFRESH_CASSETTES: false
-          
-      - name: Upload coverage to Codecov
-        if: matrix.php-version == '8.2'
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2","8.3"]'
+      extensions: "soap, libxml, mbstring"
+      coverage: "xdebug"
+      run-phpstan: false
+      # Unit suite (with Clover coverage) must pass; the integration suite is
+      # advisory and keeps its original continue-on-error semantics via `|| true`.
+      phpunit-cmd: 'vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml && { USE_PRODUCTION_ENDPOINT=false REFRESH_CASSETTES=false vendor/bin/phpunit --testsuite=integration --no-coverage || true; }'
+      upload-coverage-codecov: true
+      coverage-php-version: "8.2"
+      coverage-file: "./coverage.xml"
+      coverage-flags: "unittests"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   security:
     name: Security Scan
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: '8.2'
-          extensions: soap, libxml
-          tools: composer:v2
-          
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-        
-      - name: Run security checker
-        run: composer audit
-        
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2"]'
+      extensions: "soap, libxml"
+      run-composer-audit: true
+      run-phpstan: false
+      run-phpunit: false
+
   rector:
     name: Rector Checks
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: '8.2'
-          extensions: soap, libxml
-          tools: composer:v2
-          
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-        
-      - name: Run Rector (dry-run)
-        run: vendor/bin/rector process --dry-run --no-progress-bar
-        
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2"]'
+      extensions: "soap, libxml"
+      run-rector: true
+      run-phpstan: false
+      run-phpunit: false
+
   performance:
     name: Performance Benchmarks
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        
-      - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: '8.2'
-          extensions: soap, libxml
-          tools: composer:v2
-          
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
-        
-      - name: Run performance benchmarks
-        run: vendor/bin/phpunit tests/Integration/PerformanceBenchmarkTest.php --no-coverage
-        env:
-          USE_PRODUCTION_ENDPOINT: false
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.2"]'
+      extensions: "soap, libxml"
+      run-phpstan: false
+      phpunit-cmd: 'USE_PRODUCTION_ENDPOINT=false vendor/bin/phpunit tests/Integration/PerformanceBenchmarkTest.php --no-coverage'


### PR DESCRIPTION
## Summary

Raises `.github/workflows/quality-assurance.yml` to the shared CI standard: **zero step-level action `uses:`** — all five jobs now call `netresearch/.github/.github/workflows/php-ci.yml@main`.

The previously-assumed blocker (multi-command jobs, a second `continue-on-error` PHPUnit run with env vars, a benchmark run) turned out not to be one: `php-ci.yml` routes every command input through `bash -c "$CMD"`, so `&&`, `{ …; }`, `|| true` and inline `VAR=value` prefixes all work. **No new inputs are requested.**

## Job mapping

| Old job | New call |
|---|---|
| `static-analysis` (8.2/8.3) | `php-ci` with `phpstan-cmd: 'vendor/bin/phpstan analyse … && vendor/bin/phpcs && vendor/bin/phpmd src text phpmd.xml'`, `run-phpunit: false` |
| `tests` (8.2/8.3) | `php-ci` with `coverage: xdebug`, `phpunit-cmd` = unit-with-Clover `&& { <integration with env> \|\| true; }`, `upload-coverage-codecov: true`, `coverage-php-version: "8.2"` |
| `security` | `php-ci` with `run-composer-audit: true` |
| `rector` | `php-ci` with `run-rector: true` (reusable default command is byte-identical to the old one) |
| `performance` | `php-ci` with `phpunit-cmd: 'USE_PRODUCTION_ENDPOINT=false vendor/bin/phpunit tests/Integration/PerformanceBenchmarkTest.php --no-coverage'` |

## Preserved as functional requirements

- PHP **8.2 / 8.3 matrix** on static analysis and tests.
- `soap, libxml, mbstring` extensions; xdebug coverage driver on the tests job.
- Unit suite failure still **fails the job**; integration suite failure is still **advisory** (old `continue-on-error: true`, now `|| true` inside the same command). Verified: `bash -c 'false && { true || true; }'` exits 1, `bash -c 'true && { false || true; }'` exits 0.
- Integration env vars `USE_PRODUCTION_ENDPOINT=false` / `REFRESH_CASSETTES=false`, and `USE_PRODUCTION_ENDPOINT=false` for the benchmark run.
- Clover coverage upload to Codecov from the **8.2** matrix entry only, flag `unittests`, file `./coverage.xml`.
- `composer audit`, Rector dry-run, workflow `name`, and the `push`/`pull_request` triggers on `main` + `develop`.

## Dropped as local quirks

- **`--optimize-autoloader`** on `composer install` — the shared default is `--prefer-dist --no-progress --no-interaction`. Autoloader optimisation is a runtime-perf tweak with no effect on whether these checks pass.
- **Explicit `xdebug` in the tests job's `extensions:` list** — redundant, `coverage: xdebug` already installs the driver.
- **Codecov `name: codecov-umbrella`** — a display label; the shared reusable does not expose a `name` input.
- **Check names change** (e.g. `Static Analysis` → `Static Analysis / PHP 8.2`). Verified there are no required status checks to update: `gh api repos/netresearch/sdk-eu-vat/rules/branches/main` returns `[]` and `gh api repos/netresearch/sdk-eu-vat/branches/main/protection` contains no `required_status_checks` block.

## Gained from the shared standard

- `step-security/harden-runner` (egress audit) on every job.
- `persist-credentials: false` on checkout.
- Top-level `permissions: {}` with per-job `contents: read`.
- `composer validate --strict` before install (verified passing locally: exit 0).
- Per-PHP-version composer cache keys keyed on both `composer.json` and `composer.lock`.
- `fail-fast: false`, explicit job timeouts, newer pinned action SHAs (checkout v7, cache v6.1.0, setup-php 2.37.2, codecov v7).

## Proposals for the shared standard

None blocking. Two optional conveniences, deliberately **not** requested as special-casing:

1. `php-ci.yml` has no `codecov-name` input, so the Codecov upload label is fixed. Cosmetic only.
2. Advisory (allowed-to-fail) test runs currently have to be encoded as `|| true` inside a command string. A `phpunit-continue-on-error`-style input would make that intent explicit, but the current form is fully expressible.

## Verification

- `actionlint .github/workflows/quality-assurance.yml` → exit 0.
- `bash -n -c` on each of the three composed command strings → all parse.
- Exit-code semantics of the `A && { B || true; }` form probed directly (see above).
- `composer validate --strict` on this repo → exit 0.
- Read `netresearch/.github` `.github/workflows/php-ci.yml` in full from its `main` branch (425 lines) before mapping.

Only `.github/workflows/quality-assurance.yml` is touched; `security.yml` is out of scope and unchanged.

## CI result on this PR (run 29990275008)

| Check | Result |
|---|---|
| `Static Analysis / PHP 8.2` | pass |
| `Static Analysis / PHP 8.3` | pass |
| `Tests / PHP 8.2` | pass (all steps green, incl. Codecov upload) |
| `Tests / PHP 8.3` | pass |
| `Rector Checks / PHP 8.2` | pass |
| `Performance Benchmarks / PHP 8.2` | pass |
| `Security Scan / PHP 8.2` | **fail — pre-existing, not caused by this PR** |

`Security Scan` fails on `composer audit`: `Found 3 security vulnerability advisories affecting 1 package` — CVE-2026-45304, CVE-2026-45305, CVE-2026-45133, all in the Symfony YAML parser. Evidence that this is pre-existing and unrelated to the migration:

- The **untouched** `security.yml` workflow's independent `composer-audit / Composer Audit` job (from `netresearch/typo3-ci-workflows`) fails on the exact same commit for the same advisories.
- The last `Quality Assurance` run on `main` (run 23836221139, 2026-04-01) was green; these advisories are dated later. This is a dependency drift, fixable by a Composer update, not a workflow regression.

Behaviour confirmed in the logs rather than assumed:

- `Tests / PHP 8.3` ran **both** suites inside the one composed command — `Tests: 189, Assertions: 494` (unit, with Clover) then `OK (10 tests, 1149 assertions)` (integration).
- Codecov upload ran on **8.2 only**: step `Upload coverage to Codecov` is `success` on `Tests / PHP 8.2` and `skipped` on `Tests / PHP 8.3`.
- Every job shows `Harden Runner`, `Checkout`, `Setup PHP`, `Validate composer.json and composer.lock`, `Cache composer packages`, `Install dependencies` from the shared reusable, with the unused check steps correctly `skipped`.
