### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-30
+
 This release corrects the SOAP request encoding, the response conversion and the
 exception contract. Each of those changes alters observable behaviour for existing
-code, so the next release is a major version. Read "Breaking changes" before upgrading.
+code, which is why it is a major version. Read "Breaking changes" before upgrading.
 
 ### Breaking changes
 


### PR DESCRIPTION
Marks the accumulated `[Unreleased]` entries as `[2.0.0]`. No code changes.

Major, because the SOAP encoding, response conversion and exception contract corrections in #31 each change observable behaviour:

- `VatRate` value accessors are nullable, and preserve the scale the service sent (`"17.0"`, not `"17"`)
- `retrieveVatRates()` raises different exception types: service rejections as `InvalidRequestException`, failures that never reached the service as `ServiceUnavailableException`, and every SDK exception from response conversion now propagates unwrapped
- The documented `TEDB-100`/`101`/`102`/`400` fault codes never existed; `getErrorCode()` returns what the service actually sends
- Rate categories moved from `VatRate` to `VatRateResult`, where the schema puts them; `VatRate::getCategory()` is removed
- The event and middleware layers are removed, along with `ClientConfiguration::withMiddleware()`, `withEventSubscriber()` and `VatRetrievalClientFactory::createWithEventSubscribers()`
- `DateTypeConverter::convertPhpToXml()` and `BigDecimalTypeConverter::convertPhpToXml()` return complete XML elements
- `symfony/event-dispatcher` and `ramsey/uuid` are no longer required; `composer.lock` is no longer committed

Upgrade notes are in the CHANGELOG's Breaking changes section.

## Release process notes

Two pre-existing conditions this PR does not address:

- There is no release workflow; tagging and the GitHub release are manual (`prepare-release.sh` covers the local checks).
- `v1.0.0` is a lightweight tag rather than an annotated one. Retagging a published release would be worse than leaving it; `v1.0.1` and `v1.1.0` are annotated.

After merge, the tag is created manually:

```
git checkout main && git pull
git tag -s v2.0.0 -m "v2.0.0"
git push origin v2.0.0
```
