### PR TITLE
ci: create the GitHub Release from a pushed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+# Creates the GitHub Release entry when an annotated version tag is pushed.
+# Packagist publishes the package itself from the tag via webhook, so there is
+# nothing to build or upload here.
+#
+# Tagging stays manual and signed:
+#   git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
+#
+# The reusable workflow rejects lightweight tags, which is how v1.0.0 ended up
+# as a bare commit ref rather than a tag object.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v2.0.1). Use to backfill a release for an existing tag."
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    uses: netresearch/.github/.github/workflows/release-composer-package.yml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag || '' }}


### PR DESCRIPTION
Adds the release workflow the pre-release validation flagged as missing. Calls the org reusable `netresearch/.github/.github/workflows/release-composer-package.yml`, which this repository is the first consumer of.

Releases were manual until now. That is how `v1.0.0` ended up as a lightweight tag rather than an annotated one, and why the `v2.0.0` release entry was published from a workstation instead of from CI.

What the reusable workflow does:

- rejects lightweight tags, and verifies the tag signature when the key is available in CI
- runs `composer validate --strict` before the release is published, so a malformed `composer.json` is caught before Packagist sees it
- computes the `prerelease` and `make_latest` flags from the tag, so an older tag cannot be stamped as latest
- creates no release assets: Packagist publishes the package from the tag via webhook, and GitHub already attaches source archives

Tagging stays manual and signed:

```
git tag -s vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z
```

`workflow_dispatch` takes a tag argument so a release can be backfilled for a tag that already exists.

## Two things to know

**Release notes will be auto-generated from commits and PRs.** The reusable workflow sets `generate_release_notes: true` and exposes no way to pass a file, so future releases will not carry the CHANGELOG section the way `v2.0.0` does. If the CHANGELOG text is wanted, `gh release edit --notes-file` after the workflow runs is the way to apply it.

**Do not dispatch this for `v2.0.0`.** That release already exists with CHANGELOG-derived notes; running the workflow against that tag would replace them with auto-generated ones. The first real exercise of this workflow should be the next tag.

The skill's release-workflow check reports SBOM, cosign signing and build attestation as missing. Those belong to the generic template, which builds and signs tarballs. This workflow ships no artifacts, so there is nothing for them to act on.