### PR TITLE
chore(deps): update dependencies to their newest PHP 8.2-compatible releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `phpunit/phpunit` raised to `^11.5.56`. PHPUnit metadata moved from doc-comments to
+  attributes, because doc-comment metadata is removed in PHPUnit 12. `@test` was
+  dropped rather than converted — every annotated method is already `test`-prefixed,
+  so PHPUnit discovers it by name
+- Removed the `all` PHPUnit test suite. It re-collected files already claimed by the
+  `unit` and `integration` suites, so every test in the `--group network` CI step ran
+  twice (26 executions for 13 tests). PHPUnit 11 reports the overlap as a warning,
+  which `failOnWarning` turns into a failure. Nothing referenced the suite
 - `php-vcr/php-vcr` widened to `>=1.6.4 <1.12`. The `<1.8.2` cap recorded under 2.0.0
   is obsolete: `php-soap/ext-soap-engine` declares the `$uriParserClass` parameter
   itself as of 1.12.0, and the `SoapClient` test doubles now accept it. 1.11 also

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `php-vcr/php-vcr` widened to `>=1.6.4 <1.12`. The `<1.8.2` cap recorded under 2.0.0
+  is obsolete: `php-soap/ext-soap-engine` declares the `$uriParserClass` parameter
+  itself as of 1.12.0, and the `SoapClient` test doubles now accept it. 1.11 also
+  supports PHP 8.5, which 1.8.1 does not, so the old cap would have blocked the first
+  developer to move to 8.5. Cassettes are unaffected
+
 ## [2.0.0] - 2026-07-30
 
 This release corrects the SOAP request encoding, the response conversion and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `unit` and `integration` suites, so every test in the `--group network` CI step ran
   twice (26 executions for 13 tests). PHPUnit 11 reports the overlap as a warning,
   which `failOnWarning` turns into a failure. Nothing referenced the suite
-- `php-vcr/php-vcr` widened to `>=1.6.4 <1.12`. The `<1.8.2` cap recorded under 2.0.0
-  is obsolete: `php-soap/ext-soap-engine` declares the `$uriParserClass` parameter
-  itself as of 1.12.0, and the `SoapClient` test doubles now accept it. 1.11 also
-  supports PHP 8.5, which 1.8.1 does not, so the old cap would have blocked the first
-  developer to move to 8.5. Cassettes are unaffected
+- The `SoapClient` test doubles accept php-vcr's optional `$uriParserClass` parameter.
+  The `php-vcr/php-vcr` cap at `<1.8.2` is **retained**: raising it is impossible while
+  PHP 8.2 is supported, because `php-soap/ext-soap-engine` 1.7.0 is the only release
+  installable on 8.2 and its `AbusedClient::__doRequest()` does not declare that
+  parameter, so php-vcr 1.8.2+ fatals against it. 1.8.0 onwards requires PHP 8.3+.
+  The cap can be lifted once the floor moves off 8.2, and the test doubles are already
+  prepared for it
 
 ## [2.0.0] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- **`brick/math` now requires `^0.18`**, where `^0.11 || ^0.12` was previously accepted.
+  Consumers pinned to 0.11 or 0.12 cannot install this release. The SDK exposes
+  `BigDecimal` through `VatRate::getDecimalValue()`, so the two cannot be spanned
+  silently. 0.13 renamed the `RoundingMode` enum cases from `HALF_UP` to `HalfUp`;
+  code passing a rounding mode to a `BigDecimal` obtained from this SDK must follow
+
 ### Changed
 
 - `php-vcr/php-vcr` widened to `>=1.6.4 <1.12`. The `<1.8.2` cap recorded under 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`brick/math` now requires `^0.18`**, where `^0.11 || ^0.12` was previously accepted.
   Consumers pinned to 0.11 or 0.12 cannot install this release. The SDK exposes
-  `BigDecimal` through `VatRate::getDecimalValue()`, so the two cannot be spanned
-  silently. 0.13 renamed the `RoundingMode` enum cases from `HALF_UP` to `HalfUp`;
-  code passing a rounding mode to a `BigDecimal` obtained from this SDK must follow
+  `BigDecimal` through `VatRate::getValue()` and `VatRate::getDecimalValue()`, so the
+  ranges cannot be spanned silently. 0.14.8 renamed the `RoundingMode` enum cases from
+  `HALF_UP` to `HalfUp`, so code that passes a rounding mode to a `BigDecimal` obtained
+  from this SDK — for example `$rate->getDecimalValue()->dividedBy('100', 2,
+  RoundingMode::HalfUp)` — must use the new spelling. `src/` itself never referenced
+  `RoundingMode`; only the integration suite did
 
 ### Changed
 
@@ -31,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   installable on 8.2 and its `AbusedClient::__doRequest()` does not declare that
   parameter, so php-vcr 1.8.2+ fatals against it. 1.8.0 onwards requires PHP 8.3+.
   The cap can be lifted once the floor moves off 8.2, and the test doubles are already
-  prepared for it
+  prepared for it. Note the cost of keeping it: `php: ^8.2` admits PHP 8.5, but
+  php-vcr 1.8.1 stops at 8.4, so the dev toolchain cannot be installed on 8.5
 
 ## [2.0.0] - 2026-07-30
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.5.62",
+        "phpunit/phpunit": "^11.5.56",
         "phpstan/phpstan": "^1.10",
         "monolog/monolog": "^2.10 || ^3.0",
         "squizlabs/php_codesniffer": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "squizlabs/php_codesniffer": "^4.0",
         "slevomat/coding-standard": "^8.0",
         "rector/rector": "^1.0",
-        "php-vcr/php-vcr": ">=1.6.4 <1.12",
+        "php-vcr/php-vcr": ">=1.6.4 <1.8.2",
         "phpmd/phpmd": "^2.13",
         "symfony/event-dispatcher": "^6.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "squizlabs/php_codesniffer": "^4.0",
         "slevomat/coding-standard": "^8.0",
         "rector/rector": "^1.0",
-        "php-vcr/php-vcr": ">=1.6.4 <1.8.2",
+        "php-vcr/php-vcr": ">=1.6.4 <1.12",
         "phpmd/phpmd": "^2.13",
         "symfony/event-dispatcher": "^6.0 || ^7.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.2",
         "ext-libxml": "*",
         "ext-soap": "*",
-        "brick/math": "^0.11 || ^0.12",
+        "brick/math": "^0.18",
         "php-soap/ext-soap-engine": "^1.7",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          bootstrap="tests/fixtures/vcr-bootstrap.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
@@ -17,9 +17,6 @@
         <testsuite name="integration">
             <directory>tests/Integration</directory>
         </testsuite>
-        <testsuite name="all">
-            <directory>tests</directory>
-        </testsuite>
     </testsuites>
 
     <coverage includeUncoveredFiles="true"
@@ -33,9 +30,9 @@
         </report>
     </coverage>
 
-    <source restrictDeprecations="true"
-            restrictNotices="true"
-            restrictWarnings="true">
+    <source restrictNotices="true"
+            restrictWarnings="true"
+            ignoreIndirectDeprecations="true">
         <include>
             <directory>src</directory>
         </include>

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -262,7 +262,7 @@ class EndToEndTest extends IntegrationTestCase
             // Test financial calculations
             $netAmount = BigDecimal::of('999.99');
             $vatAmount = $netAmount->multipliedBy($decimalValue)
-                ->dividedBy('100', 2, RoundingMode::HALF_UP);
+                ->dividedBy('100', 2, RoundingMode::HalfUp);
             $grossAmount = $netAmount->plus($vatAmount);
 
             // Verify calculations maintain precision

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\EuVatSdk\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\Group;
 use Netresearch\EuVatSdk\Exception\InvalidRequestException;
 use Netresearch\EuVatSdk\Exception\SoapFaultException;
 use Netresearch\EuVatSdk\Client\SoapVatRetrievalClient;
@@ -23,19 +24,16 @@ use DateTime;
  * This test validates the entire SDK from installation to production usage,
  * including error handling, performance characteristics, and edge cases.
  *
- * @group integration
- * @group e2e
- *
  * @package Netresearch\EuVatSdk\Tests\Integration
  * @author  Netresearch DTT GmbH
  * @license https://opensource.org/licenses/MIT MIT License
  */
+#[Group('integration')]
+#[Group('e2e')]
 class EndToEndTest extends IntegrationTestCase
 {
     /**
      * Test complete workflow: installation to API call
-     *
-     * @test
      */
     public function testCompleteWorkflowFromInstallationToApiCall(): void
     {
@@ -72,8 +70,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test all supported PHP versions behavior
-     *
-     * @test
      */
     public function testPhpVersionCompatibility(): void
     {
@@ -111,10 +107,8 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test memory usage with large datasets
-     *
-     * @test
-     * @group performance
      */
+    #[Group('performance')]
     public function testMemoryUsageWithLargeDatasets(): void
     {
         $this->setupVcr('e2e-memory-usage');
@@ -154,10 +148,8 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test concurrent request handling
-     *
-     * @test
-     * @group performance
      */
+    #[Group('performance')]
     public function testConcurrentRequestHandling(): void
     {
         $this->setupVcr('e2e-concurrent-requests');
@@ -191,8 +183,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test error handling completeness
-     *
-     * @test
      */
     public function testComprehensiveErrorHandling(): void
     {
@@ -240,8 +230,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test BigDecimal precision in financial calculations
-     *
-     * @test
      */
     public function testFinancialCalculationPrecision(): void
     {
@@ -283,8 +271,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test different client configurations
-     *
-     * @test
      */
     public function testVariousClientConfigurations(): void
     {
@@ -345,10 +331,8 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test SOAP client optimization features
-     *
-     * @test
-     * @group performance
      */
+    #[Group('performance')]
     public function testSoapClientOptimizations(): void
     {
         $this->setupVcr('e2e-soap-optimizations');
@@ -390,8 +374,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test environment-specific behaviors
-     *
-     * @test
      */
     public function testEnvironmentSpecificBehaviors(): void
     {
@@ -427,8 +409,6 @@ class EndToEndTest extends IntegrationTestCase
 
     /**
      * Test edge cases and boundary conditions
-     *
-     * @test
      */
     public function testEdgeCasesAndBoundaryConditions(): void
     {

--- a/tests/Integration/ServiceInteractionTest.php
+++ b/tests/Integration/ServiceInteractionTest.php
@@ -9,6 +9,7 @@ use Netresearch\EuVatSdk\DTO\Request\VatRatesRequest;
 use Netresearch\EuVatSdk\DTO\Response\VatRateResult;
 use Netresearch\EuVatSdk\DTO\Response\VatRatesResponse;
 use Netresearch\EuVatSdk\Exception\VatServiceException;
+use PHPUnit\Framework\Attributes\Group;
 use Soap\ExtSoapEngine\AbusedClient;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use VCR\Util\SoapClient as VcrSoapClient;
@@ -28,12 +29,11 @@ use VCR\VCREvents;
  * instead of going through setupVcr(), so REFRESH_CASSETTES cannot turn a run of
  * this class into live traffic.
  *
- * @group integration
- *
  * @package Netresearch\EuVatSdk\Tests\Integration
  * @author  Netresearch DTT GmbH
  * @license https://opensource.org/licenses/MIT MIT License
  */
+#[Group('integration')]
 class ServiceInteractionTest extends IntegrationTestCase
 {
     /**
@@ -87,8 +87,6 @@ class ServiceInteractionTest extends IntegrationTestCase
      * This is the guard against a per-item network call sneaking into the client:
      * 27 member states still have to travel in a single SOAP interaction. It also
      * pins the shape of the recorded data -- one row per rate type per member state.
-     *
-     * @test
      */
     public function testFullEuResponseIsRetrievedInASingleServiceCall(): void
     {
@@ -128,8 +126,6 @@ class ServiceInteractionTest extends IntegrationTestCase
      * This is the proof that the suite is offline: VCR runs in 'once' mode, so any
      * request whose SOAP body differs from a recording is rejected locally rather
      * than being forwarded to the EU VAT service.
-     *
-     * @test
      */
     public function testUnrecordedRequestIsRejectedInsteadOfReachingTheNetwork(): void
     {

--- a/tests/Integration/VatRateErrorHandlingTest.php
+++ b/tests/Integration/VatRateErrorHandlingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\EuVatSdk\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\Group;
 use Netresearch\EuVatSdk\DTO\Response\VatRatesResponse;
 use Netresearch\EuVatSdk\Client\ClientConfiguration;
 use Netresearch\EuVatSdk\Client\SoapVatRetrievalClient;
@@ -28,19 +29,16 @@ use VCR\VCR;
  * </ns0:error></ns2:retrieveVatRatesFaultMsg></detail>
  * ```
  *
- * @group integration
- * @group network
- *
  * @package Netresearch\EuVatSdk\Tests\Integration
  * @author  Netresearch DTT GmbH
  * @license https://opensource.org/licenses/MIT MIT License
  */
+#[Group('integration')]
+#[Group('network')]
 class VatRateErrorHandlingTest extends IntegrationTestCase
 {
     /**
      * Unknown member state codes are rejected by the service with TEDB-ERR-2
-     *
-     * @test
      */
     public function testInvalidCountryCodeError(): void
     {
@@ -67,8 +65,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
      *
      * VatRatesRequest rejects it in its own constructor, so no SOAP fault mapping
      * is involved and the cassette for this scenario is empty.
-     *
-     * @test
      */
     public function testEmptyMemberStatesError(): void
     {
@@ -89,8 +85,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
      * Dates beyond the accepted range never reach the service either
      *
      * VatRatesRequest caps the situation date at five years into the future.
-     *
-     * @test
      */
     public function testFutureDateError(): void
     {
@@ -109,8 +103,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
 
     /**
      * Non-EU country codes produce the same TEDB-ERR-2 fault
-     *
-     * @test
      */
     public function testNonEuCountryCodeError(): void
     {
@@ -135,8 +127,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
      *
      * The recorded response is a plain HTTP 200 with UK rate results, so the
      * service does not treat GB as an unknown member state.
-     *
-     * @test
      */
     public function testBrexitTransitionHandling(): void
     {
@@ -159,8 +149,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
 
     /**
      * A single unknown code rejects the whole request
-     *
-     * @test
      */
     public function testMixedValidInvalidCountryCodes(): void
     {
@@ -182,11 +170,9 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
 
     /**
      * Test timeout handling
-     *
-     * @test
-     * @group slow
-     * @group network
      */
+    #[Group('slow')]
+    #[Group('network')]
     public function testTimeoutHandling(): void
     {
         // Create a client with very short timeout
@@ -219,8 +205,6 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
 
     /**
      * Test handling of malformed SOAP response
-     *
-     * @test
      */
     public function testMalformedResponseHandling(): void
     {

--- a/tests/Integration/VatRateRetrievalTest.php
+++ b/tests/Integration/VatRateRetrievalTest.php
@@ -9,23 +9,21 @@ use Netresearch\EuVatSdk\DTO\Request\VatRatesRequest;
 use Netresearch\EuVatSdk\DTO\Response\VatRatesResponse;
 use Netresearch\EuVatSdk\DTO\Response\VatRateResult;
 use Netresearch\EuVatSdk\DTO\Response\VatRate;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Integration tests for successful VAT rate retrieval scenarios
- *
- * @group integration
- * @group network
  *
  * @package Netresearch\EuVatSdk\Tests\Integration
  * @author  Netresearch DTT GmbH
  * @license https://opensource.org/licenses/MIT MIT License
  */
+#[Group('integration')]
+#[Group('network')]
 class VatRateRetrievalTest extends IntegrationTestCase
 {
     /**
      * Test successful retrieval of VAT rates for a single member state
-     *
-     * @test
      */
     public function testRetrieveSingleCountryVatRates(): void
     {
@@ -66,8 +64,6 @@ class VatRateRetrievalTest extends IntegrationTestCase
 
     /**
      * Test retrieval of VAT rates for multiple EU member states
-     *
-     * @test
      */
     public function testRetrieveMultipleCountriesVatRates(): void
     {
@@ -113,8 +109,6 @@ class VatRateRetrievalTest extends IntegrationTestCase
 
     /**
      * Test retrieval with historical date (Brexit transition)
-     *
-     * @test
      */
     public function testRetrieveHistoricalVatRates(): void
     {
@@ -147,8 +141,6 @@ class VatRateRetrievalTest extends IntegrationTestCase
 
     /**
      * Test retrieval with all current EU member states
-     *
-     * @test
      */
     public function testRetrieveAllEuMemberStatesVatRates(): void
     {
@@ -198,8 +190,6 @@ class VatRateRetrievalTest extends IntegrationTestCase
 
     /**
      * Test decimal precision handling
-     *
-     * @test
      */
     public function testVatRateDecimalPrecision(): void
     {
@@ -260,8 +250,6 @@ class VatRateRetrievalTest extends IntegrationTestCase
      * results carry none. Both halves are asserted here: a real identifier and its
      * description must arrive intact, and the uncategorised standard rate must
      * report null without disturbing the rest of the response.
-     *
-     * @test
      */
     public function testRetrievedResultsCarryCategories(): void
     {

--- a/tests/README.md
+++ b/tests/README.md
@@ -118,9 +118,6 @@ happens and a later replay would reach the live service instead.
 ```php
 class MyComponentTest extends TestCase
 {
-    /**
-     * @test
-     */
     public function testComponentBehavior(): void
     {
         $component = new MyComponent();
@@ -135,12 +132,11 @@ class MyComponentTest extends TestCase
 ### Integration Test Example
 
 ```php
+use PHPUnit\Framework\Attributes\Group;
+
 class MyIntegrationTest extends IntegrationTestCase
 {
-    /**
-     * @test
-     * @group integration
-     */
+    #[Group('integration')]
     public function testRealServiceInteraction(): void
     {
         // Insert cassette for recording/replay
@@ -213,7 +209,9 @@ the test itself (`ClientConfiguration::test()` already does).
 2. **Use VCR**: Don't make real network calls in CI
 3. **Test Edge Cases**: Include boundary conditions and error scenarios
 4. **Mock External Dependencies**: Use PHPUnit mocks for unit tests
-5. **Group Related Tests**: Use `@group` annotations for organization
+5. **Group Related Tests**: Use `#[Group('name')]` attributes for organization. PHPUnit
+   metadata belongs in attributes, not doc-comments — doc-comment metadata is removed
+   in PHPUnit 12
 6. **Document Complex Tests**: Add comments explaining test scenarios
 7. **Maintain Cassettes**: Periodically refresh to catch API changes
 

--- a/tests/Unit/Client/SoapVatRetrievalClientTest.php
+++ b/tests/Unit/Client/SoapVatRetrievalClientTest.php
@@ -227,12 +227,16 @@ class SoapVatRetrievalClientTest extends TestCase
             'uri' => 'urn:eu-vat-sdk-test',
             'exceptions' => true,
         ]) extends \SoapClient {
+            // php-vcr rewrites `extends \SoapClient` to extend its own SoapClient, which
+            // from 1.8.2 declares this extra optional parameter. Accepting it keeps the
+            // override valid against that parent and against plain \SoapClient alike.
             public function __doRequest(
                 string $request,
                 string $location,
                 string $action,
                 int $version,
-                bool $oneWay = false
+                bool $oneWay = false,
+                ?string $uriParserClass = null
             ): string {
                 return 'Proxy authentication required';
             }

--- a/tests/Unit/Converter/VatRatesResponseConverterTest.php
+++ b/tests/Unit/Converter/VatRatesResponseConverterTest.php
@@ -8,6 +8,7 @@ use Brick\Math\BigDecimal;
 use DateTimeImmutable;
 use Netresearch\EuVatSdk\Converter\VatRatesResponseConverter;
 use Netresearch\EuVatSdk\Exception\ConversionException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -64,9 +65,8 @@ class VatRatesResponseConverterTest extends TestCase
      * minOccurs="0" inside rateValueType, which applies to every member of
      * rateValueTypeEnum. A missing value is schema-valid for any rate type,
      * so conversion must yield a VatRate with a null value instead of failing.
-     *
-     * @dataProvider provideRateTypes
      */
+    #[DataProvider('provideRateTypes')]
     public function testConvertsRateWithoutValueForAnyRateType(string $rateType): void
     {
         $response = new stdClass();
@@ -255,9 +255,8 @@ class VatRatesResponseConverterTest extends TestCase
     /**
      * A malformed category (element present but without a usable identifier) must
      * degrade to null instead of aborting the whole response.
-     *
-     * @dataProvider malformedCategoryProvider
      */
+    #[DataProvider('malformedCategoryProvider')]
     public function testMalformedCategoryDegradesToNull(?string $identifier, ?string $description): void
     {
         $result = $this->attachCategory(

--- a/tests/Unit/EventListener/FaultEventListenerTest.php
+++ b/tests/Unit/EventListener/FaultEventListenerTest.php
@@ -8,6 +8,7 @@ use Netresearch\EuVatSdk\EventListener\FaultEventListener;
 use Netresearch\EuVatSdk\Exception\InvalidRequestException;
 use Netresearch\EuVatSdk\Exception\ServiceUnavailableException;
 use Netresearch\EuVatSdk\Exception\SoapFaultException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use SoapFault;
@@ -139,9 +140,8 @@ class FaultEventListenerTest extends TestCase
      * service response: a proxy or captive portal answering with HTML, a truncated
      * body, an encoding failure. No request was rejected, and the condition is
      * usually transient, so the retryable exception is the correct contract.
-     *
-     * @dataProvider localExtSoapFailureProvider
      */
+    #[DataProvider('localExtSoapFailureProvider')]
     public function testLocalExtSoapFailureMapsToServiceUnavailableException(string $faultString): void
     {
         $fault = new SoapFault('Client', $faultString);

--- a/tests/Unit/TypeConverter/BigDecimalTypeConverterTest.php
+++ b/tests/Unit/TypeConverter/BigDecimalTypeConverterTest.php
@@ -257,12 +257,16 @@ class BigDecimalTypeConverterTest extends TestCase
         ]) extends \SoapClient {
             public string $recordedResponse = '';
 
+            // php-vcr rewrites `extends \SoapClient` to extend its own SoapClient, which
+            // from 1.8.2 declares this extra optional parameter. Accepting it keeps the
+            // override valid against that parent and against plain \SoapClient alike.
             public function __doRequest(
                 string $request,
                 string $location,
                 string $action,
                 int $version,
-                bool $oneWay = false
+                bool $oneWay = false,
+                ?string $uriParserClass = null
             ): ?string {
                 return $this->recordedResponse;
             }

--- a/tests/Unit/TypeConverter/DateTypeConverterTest.php
+++ b/tests/Unit/TypeConverter/DateTypeConverterTest.php
@@ -110,12 +110,16 @@ class DateTypeConverterTest extends TestCase
         ]) extends \SoapClient {
             public string $capturedRequest = '';
 
+            // php-vcr rewrites `extends \SoapClient` to extend its own SoapClient, which
+            // from 1.8.2 declares this extra optional parameter. Accepting it keeps the
+            // override valid against that parent and against plain \SoapClient alike.
             public function __doRequest(
                 string $request,
                 string $location,
                 string $action,
                 int $version,
-                bool $oneWay = false
+                bool $oneWay = false,
+                ?string $uriParserClass = null
             ): ?string {
                 $this->capturedRequest = $request;
                 return '';


### PR DESCRIPTION
Brings every dev and runtime dependency to the newest release that still installs on
PHP 8.2, ahead of the separate change that raises the floor to 8.4. Supersedes the
Renovate PRs listed below.

Target versions were resolved by Composer against a pinned `platform.php = 8.2.33`
rather than read off Packagist, because the p2 metadata endpoint is minified — an
absent `require.php` inherits from the preceding entry instead of meaning
"unconstrained".

| Package | Before | After | Highest on 8.2 |
|---|---|---|---|
| `php-vcr/php-vcr` | `>=1.6.4 <1.8.2` | unchanged — see below | 1.8.1 (on 8.2) |
| `brick/math` | `^0.11 \|\| ^0.12` | `^0.18` | 0.18.0 |
| `phpunit/phpunit` | `^10.5.62` | `^11.5.56` | 11.5.56 |

`squizlabs/php_codesniffer` v4 landed separately in #13.

## Breaking change

`brick/math` now requires `^0.18`; consumers pinned to 0.11 or 0.12 cannot install
this release. 0.14.8 renamed the `RoundingMode` enum cases (`HALF_UP` -> `HalfUp`) —
0.13.1 and 0.14.0 still declare `HALF_UP` — and since `BigDecimal` is part of the
public surface via `VatRate::getValue()` and `getDecimalValue()`, the range cannot be
spanned silently. `>=0.14.8 <0.19` would be the minimal constraint; `^0.18` is
deliberate, at the cost of a composer.json release on each brick/math minor. **This makes the next release a major.**

`src/` never referenced `RoundingMode` — the only occurrence was one assertion in the
integration suite.

## php-vcr — cap retained

The `<1.8.2` cap **stays**. Raising it is impossible while PHP 8.2 is supported:
`php-soap/ext-soap-engine` 1.7.0 is the only release installable on 8.2 (1.8.0+ needs
8.3+), and its `AbusedClient::__doRequest()` lacks the `$uriParserClass` parameter that
php-vcr 1.8.2+ adds to the parent it rewrites `SoapClient` into. The mismatch is a
fatal error raised from the bootstrap, before any test runs.

CI on this PR caught it: the bump passed 8.3 and 8.4 (which resolve ext-soap-engine
1.11.0 and 1.12.0) and died only on 8.2. It reproduces locally with
`config.platform.php = 8.2.33`.

The three anonymous SoapClient subclasses in the unit suite still gain the optional
`$uriParserClass`. An extra optional parameter is LSP-legal against the capped php-vcr
and plain SoapClient alike, so lifting the cap becomes a one-line change once the floor
moves. Keeping it does cost PHP 8.5 support for the dev toolchain: `php: ^8.2` admits
8.5, but php-vcr 1.8.1 stops at 8.4.

## PHPUnit

Doc-comment metadata is removed in PHPUnit 12, so it is converted now to keep the
later step mechanical: `@dataProvider` and `@group` become `#[DataProvider]` and
`#[Group]`. `@test` is deleted rather than converted — all 26 annotated methods are
already `test`-prefixed and discovered by name.

Group selection is provably unchanged: the test *sets* selected by `--group network`,
`--group performance` and `--testsuite=integration` are identical to before, not just
equal in count.

### Unrelated bug this surfaced

The `all` test suite re-collected files already claimed by `unit` and `integration`,
so every test in the `--group network` CI step ran **twice — 26 executions for 13
tests**. PHPUnit 10 did this silently; 11 reports the overlap as a runner warning,
which `failOnWarning="true"` makes fatal. Nothing referenced the suite, so it is
removed. A bare `vendor/bin/phpunit` still collects all 203 tests.

`restrictDeprecations` is replaced by `ignoreIndirectDeprecations` per
`--migrate-configuration`. The old attribute is still parsed and applied by PHPUnit
11.5.56 (`Runner/IssueFilter.php`, `TextUI/Configuration/Merger.php`) but was dropped
from the bundled XSD, so keeping it trips the deprecated-schema warning. The
replacement is *less* suppressive, not more: the old flag filtered on the triggering
file and so hid deprecations that `src/` caused by calling a deprecated vendor API,
while the new one hides only vendor-to-vendor triggers. Verified by
injecting a deprecation into `src/` that the suite exercises: it is still detected and
reported, and exit status is unaffected either way since `failOnDeprecation` was never
set.

## Verification

All run locally against the exact CI commands:

| Check | Result |
|---|---|
| `--testsuite=unit` | OK, 191 tests, exit 0 |
| `--testsuite=integration` | OK, 12 tests, exit 0 |
| `--group network` | OK, 13 tests, exit 0 |
| phpstan / phpcs / phpmd / rector | all exit 0 |
| `composer audit` / `validate --strict` | clean |

Local runs were on PHP 8.4.23; the 8.2 and 8.3 legs are proven by platform-pinned
resolution and will be confirmed by CI here.

## Deferred

`phpstan/phpstan` v2 (#6) and `rector/rector` v2 (#9) are a mirror-image deadlock —
Rector 1.x requires phpstan ^1.x and Rector 2.x requires ^2.x, so neither can go
green alone and they must land as one commit. Both are 8.2-compatible, but they are
dev-only and invisible to consumers, and cost 24 new PHPStan findings plus 14
Rector-modified files. Better done alongside the 8.4 floor raise, when `rector.php`
is being edited for `UP_TO_PHP_84` anyway.

Supersedes #2 and #20. #32 cannot be applied while 8.2 is supported. #10 (symfony/event-dispatcher v8) is separately unusable at
any PHP version: php-vcr constrains event-dispatcher to `^4|^5|^6|^7` at every
release, so v8 can never install — CI resolved v7.4.15 even on the PHP 8.4 leg.

