### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-07-30
+
+The last release supporting PHP 8.2. Every dependency is moved to the newest version
+installable on 8.2; the floor rises to 8.4 in the next major, where the remaining
+tooling updates land.
+
 ### Breaking changes
 
 - **`brick/math` now requires `^0.18`**, where `^0.11 || ^0.12` was previously accepted.


### PR DESCRIPTION
Promotes `[Unreleased]` to `[3.0.0]`. No version files to bump — `composer.json`
carries no `version` field, so Packagist derives it from the tag.

Major because `brick/math` narrowed to `^0.18`: consumers pinned to `^0.11`/`^0.12`
cannot install this release.

This is the **last release supporting PHP 8.2**. The floor moves to `^8.4` in the next
major, which is where `phpstan/phpstan` v2 and `rector/rector` v2 land — they are a
mutual deadlock (Rector 1.x requires phpstan ^1.x, Rector 2.x requires ^2.x) and must
go in as one change. The `php-vcr` cap at `<1.8.2` can also be lifted there, in one
line, since the test doubles already accept the parameter that forced it.

Contents (merged in #13 and #35):

| Package | 2.0.0 | 3.0.0 |
|---|---|---|
| `brick/math` | `^0.11 \|\| ^0.12` | `^0.18` |
| `phpunit/phpunit` | `^10.5.62` | `^11.5.56` |
| `squizlabs/php_codesniffer` | `^3.7` | `^4.0` |
| `php-vcr/php-vcr` | `>=1.6.4 <1.8.2` | unchanged (blocked by 8.2) |