### PR TITLE
docs(ci): record why the release workflow omits attestation permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ name: Release
 #
 # The reusable workflow rejects lightweight tags, which is how v1.0.0 ended up
 # as a bare commit ref rather than a tag object.
+#
+# No `id-token: write` / `attestations: write` here, deliberately. Release linters
+# flag their absence, but build provenance attests artefacts a workflow builds and
+# uploads, and this one builds nothing — Packagist fetches the source from the tag.
+# The reusable workflow declares no attestation, SBOM or cosign step either, so the
+# permissions would grant token scope nothing consumes. The signed tag is what
+# carries provenance for this package.
 
 on:
   push:


### PR DESCRIPTION
Comment-only change to `.github/workflows/release.yml`. No behaviour change.

Release-readiness linters flag the absence of `id-token: write` and `attestations: write`. Verified that adding them would be inert:

- The reusable workflow (`netresearch/.github/.github/workflows/release-composer-package.yml`) contains no `attest`, `sbom`, `cosign` or `id-token` references. It declares `contents: read` at top level and `contents: write` on the job, and only creates the GitHub Release entry.
- There is no artefact to attest — this is a source-distributed Composer package, and Packagist fetches from the tag via webhook. `attest-build-provenance` attests uploaded artefacts.

Provenance for this package comes from the signed annotated tag (v3.0.0 verifies against the maintainer's key).

Documenting the reasoning in the file so the finding is not re-litigated on each release.