### PR TITLE
chore(deps)!: raise the PHP floor to ^8.4 and land the deferred updates (v4.0.0)

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2","8.3","8.4"]'
+      php-versions: '["8.4","8.5"]'
       extensions: "soap, libxml, mbstring"
       coverage: "none"
       phpstan-cmd: 'vendor/bin/phpstan analyse --no-progress --error-format=github && vendor/bin/phpcs && vendor/bin/phpmd src text phpmd.xml'
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2","8.3","8.4"]'
+      php-versions: '["8.4","8.5"]'
       extensions: "soap, libxml, mbstring"
       coverage: "xdebug"
       run-phpstan: false
@@ -39,7 +39,7 @@ jobs:
       # behind a green badge.
       phpunit-cmd: 'vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml && USE_PRODUCTION_ENDPOINT=false REFRESH_CASSETTES=false vendor/bin/phpunit --testsuite=integration --no-coverage && USE_PRODUCTION_ENDPOINT=false REFRESH_CASSETTES=false vendor/bin/phpunit --group network --no-coverage'
       upload-coverage-codecov: true
-      coverage-php-version: "8.2"
+      coverage-php-version: "8.4"
       coverage-file: "./coverage.xml"
       coverage-flags: "unittests"
     secrets:
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2"]'
+      php-versions: '["8.4"]'
       extensions: "soap, libxml"
       run-composer-audit: true
       run-phpstan: false
@@ -63,7 +63,7 @@ jobs:
     permissions:
       contents: read
     with:
-      php-versions: '["8.2"]'
+      php-versions: '["8.4"]'
       extensions: "soap, libxml"
       run-rector: true
       run-phpstan: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ floor was holding back, including the runtime SOAP engine.
   carried an `@deprecated` tag since 1.0.0. `getDecimalValue()` was a plain alias of
   `getValue()`; replace it one-for-one. `getValueAsFloat()` has no direct replacement
   by design — reintroducing float rounding into a VAT calculation is the bug the
-  `BigDecimal` return type exists to prevent. Use `getValue()` and stay in decimal, or
-  call `->toFloat()` on the result at the point where a float is genuinely needed
+  `BigDecimal` return type exists to prevent. Use `getValue()` and stay in decimal. Where
+  a float is genuinely needed, note that `getValue()` is nullable, so the replacement is
+  `$rate->getValue()?->toFloat()` — the removed method used the null-safe operator too,
+  and dropping it fatals on any rate the member state does not levy
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+The PHP 8.4 major. It raises the floor to `^8.4` and lands every update that the 8.2
+floor was holding back, including the runtime SOAP engine.
+
+### Breaking changes
+
+- **PHP `^8.4` is now required**, where `^8.2` was previously accepted. This is the
+  change that unblocks everything below: `php-soap/ext-soap-engine` 1.8.0 onwards
+  requires PHP 8.3+, and 1.12.0 requires `~8.4.0 || ~8.5.0`, so 1.7.0 was the only
+  release installable on the old floor. PHP 8.5 is supported and covered by CI
+- **`php-soap/ext-soap-engine` now requires `^1.12`**, where `^1.7` was previously
+  accepted. This is a runtime dependency, so consumers pinned below 1.12 cannot
+  install this release
+- **`VatRate::getDecimalValue()` and `VatRate::getValueAsFloat()` are removed.** Both
+  carried an `@deprecated` tag since 1.0.0. `getDecimalValue()` was a plain alias of
+  `getValue()`; replace it one-for-one. `getValueAsFloat()` has no direct replacement
+  by design — reintroducing float rounding into a VAT calculation is the bug the
+  `BigDecimal` return type exists to prevent. Use `getValue()` and stay in decimal, or
+  call `->toFloat()` on the result at the point where a float is genuinely needed
+
+### Changed
+
+- `php-vcr/php-vcr` raised to `>=1.6.4 <1.12`, from `>=1.6.4 <1.8.2`. The cap existed
+  only because `ext-soap-engine` 1.7.0's `AbusedClient::__doRequest()` does not declare
+  the `$uriParserClass` parameter php-vcr 1.8.2+ requires; 1.12.0 declares it. The
+  lower bound is deliberate and stays — it excludes 1.6.3 and below
+- `phpunit/phpunit` raised to `^13.0`, from `^11.5.56`. v3.0.0 had already converted all
+  metadata to attributes, which is the migration PHPUnit 12 forces, so no test metadata
+  changed here. PHPUnit 13 reports a notice for every `createMock()` whose double never
+  receives an expectation; those doubles are now `createStub()`, and the two fault-logging
+  tests that do assert on the logger build their own mock locally
+- `phpstan/phpstan` raised to `^2.2.6` and `rector/rector` to `^2.5`, in one step. Neither
+  could move alone: Rector 1.x requires `phpstan ^1.x` and Rector 2.x requires `^2.x`
+- Rector now targets `UP_TO_PHP_84`, which is the payoff for doing the tooling bump
+  alongside the floor raise. Class constants gained types, `ReflectionMethod::setAccessible()`
+  calls were dropped, and `new Foo()->bar()` replaced the parenthesised form
+- `phpstan.neon` no longer sets `checkGenericClassInNonGenericObjectType` — PHPStan 2
+  rejects the key and refuses to start. Ten of the fifteen `ignoreErrors` patterns no
+  longer matched anything and were removed, among them a blanket
+  `If condition is always true.` that would have masked real findings
+
+### Fixed
+
+- Four pieces of dead defensive code that PHPStan 2 surfaced in `src/`: a `?? new NullLogger()`
+  behind a non-nullable `ClientConfiguration::$logger`, an `instanceof stdClass` guarded by
+  a `@var stdClass` that made it unconditionally true, and a `?? ''` on a value already
+  narrowed to non-null. The `instanceof` guard is kept and the misleading annotation removed,
+  so the check now does what it was written to do
+- `@SuppressWarnings(PHPMD.*)` annotations are quoted. phpdoc-parser 2.x fails to parse the
+  unquoted form, which PHPStan 2 reports as four parse errors
+
 ## [3.0.0] - 2026-07-30
 
 The last release supporting PHP 8.2. Every dependency is moved to the newest version

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -8,10 +8,10 @@ This SDK requires the `soap` and `libxml` PHP extensions.
 
 ```bash
 sudo apt-get update
-sudo apt-get install php8.2-soap php8.2-xml
+sudo apt-get install php8.4-soap php8.4-xml
 
-# For PHP 8.3, adjust the version number accordingly
-sudo apt-get install php8.3-soap php8.3-xml
+# For PHP 8.5, adjust the version number accordingly
+sudo apt-get install php8.5-soap php8.5-xml
 ```
 
 ### CentOS/RHEL/Fedora
@@ -27,16 +27,16 @@ sudo yum install php-soap php-xml
 ### Alpine Linux
 
 ```bash
-apk add php82-soap php82-xml
+apk add php84-soap php84-xml
 
-# For PHP 8.3, adjust the version number accordingly
-apk add php83-soap php83-xml
+# For PHP 8.5, adjust the version number accordingly
+apk add php85-soap php85-xml
 ```
 
 ### macOS (Homebrew)
 
 ```bash
-brew install php@8.2
+brew install php@8.4
 
 # Extensions are usually included, but verify they're enabled
 php -m | grep -E '(soap|libxml)'
@@ -99,6 +99,6 @@ composer config --global https-proxy https://proxy.company.com:8080
 
 If you continue to experience installation problems after following this guide, please:
 
-1. Check that your PHP version is 8.2 or higher: `php -v`
+1. Check that your PHP version is 8.4 or higher: `php -v`
 2. Verify all required extensions are loaded: `php -m | grep -E '(soap|libxml)'`
 3. Review the [README.md](README.md) for usage examples once installation is complete

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest Stable Version](https://poser.pugx.org/netresearch/sdk-eu-vat/v/stable)](https://packagist.org/packages/netresearch/sdk-eu-vat)
 [![License](https://poser.pugx.org/netresearch/sdk-eu-vat/license)](https://packagist.org/packages/netresearch/sdk-eu-vat)
 
-A modern PHP 8.2+ SDK for the [EU VAT Retrieval Service](https://ec.europa.eu/taxation_customs/tedb/) that provides reliable access to official VAT rates for all EU member states, decoded into arbitrary-precision decimals rather than floats.
+A modern PHP 8.4+ SDK for the [EU VAT Retrieval Service](https://ec.europa.eu/taxation_customs/tedb/) that provides reliable access to official VAT rates for all EU member states, decoded into arbitrary-precision decimals rather than floats.
 
 ## Features
 
@@ -23,7 +23,7 @@ A modern PHP 8.2+ SDK for the [EU VAT Retrieval Service](https://ec.europa.eu/ta
 composer require netresearch/sdk-eu-vat
 ```
 
-**Requirements:** PHP 8.2+, `ext-soap` and `ext-libxml` extensions
+**Requirements:** PHP 8.4+, `ext-soap` and `ext-libxml` extensions
 
 💡 **Having installation issues?** See the [Installation Guide](INSTALLATION.md) for troubleshooting help.
 
@@ -325,7 +325,8 @@ composer audit
 
 ### Development Requirements
 
-- PHP 8.2+
+- PHP 8.4.1+ (the library itself runs on any 8.4; PHPUnit 13 requires 8.4.1, which
+  is the first PHP 8.4 release that shipped as GA)
 - Composer 2.0+
 - All quality tools must pass (PHPStan level 8, PHPCS PSR-12)
 

--- a/composer.json
+++ b/composer.json
@@ -18,21 +18,21 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "ext-libxml": "*",
         "ext-soap": "*",
         "brick/math": "^0.18",
-        "php-soap/ext-soap-engine": "^1.7",
+        "php-soap/ext-soap-engine": "^1.12",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5.56",
-        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^13.0",
+        "phpstan/phpstan": "^2.2.6",
         "monolog/monolog": "^2.10 || ^3.0",
         "squizlabs/php_codesniffer": "^4.0",
         "slevomat/coding-standard": "^8.0",
-        "rector/rector": "^1.0",
-        "php-vcr/php-vcr": ">=1.6.4 <1.8.2",
+        "rector/rector": "^2.5",
+        "php-vcr/php-vcr": ">=1.6.4 <1.12",
         "phpmd/phpmd": "^2.13",
         "symfony/event-dispatcher": "^6.0 || ^7.0"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,18 +12,18 @@ parameters:
 
     # Custom error patterns for financial SDK
     ignoreErrors:
-        # PHPUnit mock objects have dynamic expects() method
-        - '#Call to an undefined method .+Interface::expects\(\)\.#'
-
         # Test helper methods that are dynamically created
         - '#Call to an undefined method .+::getConfiguration\(\)\.#'
 
         # Reflection method access in tests
-        - '#Cannot call method setAccessible\(\) on ReflectionMethod\|null\.#'
         - '#Cannot call method invoke\(\) on ReflectionMethod\|null\.#'
 
         # Test data type mismatches (acceptable in unit tests)
         - '#Parameter \#1 \$memberStates of class .+VatRatesRequest constructor expects array<string>, array<int, int> given\.#'
 
     # Ensure proper type declarations
-    reportUnmatchedIgnoredErrors: false
+    #
+    # A pattern that stops matching is reported rather than ignored. Suppressing
+    # that report is what let twelve of the original fifteen patterns rot into
+    # place unnoticed, one of them a blanket rule that masked a real finding.
+    reportUnmatchedIgnoredErrors: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,50 +4,26 @@ parameters:
         - src
         - tests
         - examples
-    
+
     # Exclude vendor and generated files
     excludePaths:
         - vendor/*
         - tests/fixtures/cassettes/*
-    
+
     # Custom error patterns for financial SDK
     ignoreErrors:
         # PHPUnit mock objects have dynamic expects() method
         - '#Call to an undefined method .+Interface::expects\(\)\.#'
-        
-        # VCR library uses dynamic methods not visible to PHPStan
-        - '#Call to static method .+ on an unknown class .+VCR\.#'
-        - '#Static method VCR\\VCR::insertCassette\(\) invoked with 2 parameters, 1 required\.#'
-        - '#Call to protected static method enableLibraryHooks\(\) of class VCR\\Videorecorder\.#'
-        - '#Static method VCR\\Videorecorder::enableLibraryHooks\(\) invoked with 1 parameter, 0 required\.#'
-        
-        # VCR configuration parameter type mismatch  
-        - '#Parameter \#1 \$paths of method VCR\\\\Configuration::setWhiteList\(\)#'
-        - '#Parameter \#1 \$paths of method VCR\\Configuration::setWhiteList\(\)#'
-        
+
         # Test helper methods that are dynamically created
-        - '#Call to an undefined method .+::getResults\(\)\.#'
         - '#Call to an undefined method .+::getConfiguration\(\)\.#'
-        
-        # BigDecimal toString method
-        - '#Cannot call method __toString\(\) on string\.#'
-        
-        # Anonymous class return types in tests
-        - '#Method class@anonymous/.+::getResults\(\) has no return type specified\.#'
-        
-        # Always true conditions from fault code checks (acceptable defensive programming)
-        - '#If condition is always true\.#'
-        
+
         # Reflection method access in tests
         - '#Cannot call method setAccessible\(\) on ReflectionMethod\|null\.#'
         - '#Cannot call method invoke\(\) on ReflectionMethod\|null\.#'
-        
+
         # Test data type mismatches (acceptable in unit tests)
         - '#Parameter \#1 \$memberStates of class .+VatRatesRequest constructor expects array<string>, array<int, int> given\.#'
-    
-    # Strict rules for exception handling  
-    checkGenericClassInNonGenericObjectType: true
-    
+
     # Ensure proper type declarations
     reportUnmatchedIgnoredErrors: false
-    

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.2/phpunit.xsd"
          bootstrap="tests/fixtures/vcr-bootstrap.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ use Rector\CodeQuality\Rector\ClassMethod\LocallyCalledStaticMethodToNonStaticRe
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
+use Rector\TypeDeclaration\Rector\Class_\TypedPropertyFromCreateMockAssignRector;
 
 return static function (RectorConfig $rectorConfig): void {
     // Paths to refactor
@@ -27,11 +28,16 @@ return static function (RectorConfig $rectorConfig): void {
         // Promoting classes to `readonly` is a BC break for consumers that
         // extend or mock them, so leave the class-level modifier alone.
         \Rector\Php82\Rector\Class_\ReadOnlyClassRector::class,
+
+        // Retyping a mocked test property from the interface it doubles to
+        // MockObject discards the contract the test is written against, and
+        // leaves static analysis unable to check the mocked calls.
+        TypedPropertyFromCreateMockAssignRector::class,
     ]);
 
     // PHP version and sets
     $rectorConfig->sets([
-        LevelSetList::UP_TO_PHP_82,
+        LevelSetList::UP_TO_PHP_84,
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::TYPE_DECLARATION,

--- a/src/Client/ClientConfiguration.php
+++ b/src/Client/ClientConfiguration.php
@@ -51,22 +51,22 @@ final class ClientConfiguration
     /**
      * EU VAT Retrieval Service production endpoint
      */
-    public const ENDPOINT_PRODUCTION = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService';
+    public const string ENDPOINT_PRODUCTION = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService';
 
     /**
      * EU VAT Retrieval Service acceptance/test endpoint
      */
-    public const ENDPOINT_TEST = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService-ACC';
+    public const string ENDPOINT_TEST = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService-ACC';
 
     /**
      * Default connection timeout in seconds
      */
-    public const DEFAULT_TIMEOUT = 30;
+    public const int DEFAULT_TIMEOUT = 30;
 
     /**
      * Maximum reasonable timeout in seconds
      */
-    public const MAX_TIMEOUT = 300;
+    public const int MAX_TIMEOUT = 300;
 
     /**
      * Service endpoint URL for SOAP requests

--- a/src/Client/SoapVatRetrievalClient.php
+++ b/src/Client/SoapVatRetrievalClient.php
@@ -23,7 +23,6 @@ use Soap\ExtSoapEngine\ExtSoapOptions;
 use Soap\ExtSoapEngine\Transport\ExtSoapClientTransport;
 use Soap\ExtSoapEngine\Exception\RequestException;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 use Netresearch\EuVatSdk\EventListener\FaultEventListener;
 use Netresearch\EuVatSdk\Telemetry\TelemetryInterface;
 
@@ -52,7 +51,7 @@ use Netresearch\EuVatSdk\Telemetry\TelemetryInterface;
  * $response = $client->retrieveVatRates($request);
  * ```
  *
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  * Note: High coupling is justified as this is a central integration point that orchestrates
  * SOAP engine, DTOs, exceptions, type converters, logging, and WSDL validation.
  * Future refactoring should extract concerns like DTO mapping, exception handling,
@@ -67,12 +66,12 @@ class SoapVatRetrievalClient implements VatRetrievalClientInterface
     /**
      * Default path to local WSDL file
      */
-    private const LOCAL_WSDL_PATH = __DIR__ . '/../../resources/VatRetrievalService.wsdl';
+    private const string LOCAL_WSDL_PATH = __DIR__ . '/../../resources/VatRetrievalService.wsdl';
 
     /**
      * Remote WSDL URL for fallback
      */
-    private const REMOTE_WSDL_URL = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService.wsdl';
+    private const string REMOTE_WSDL_URL = 'https://ec.europa.eu/taxation_customs/tedb/ws/VatRetrievalService.wsdl';
 
     /**
      * SOAP engine instance for making requests
@@ -97,7 +96,7 @@ class SoapVatRetrievalClient implements VatRetrievalClientInterface
     /**
      * Operation name reported to telemetry
      */
-    private const OPERATION = 'retrieveVatRates';
+    private const string OPERATION = 'retrieveVatRates';
 
 
     /**
@@ -113,7 +112,7 @@ class SoapVatRetrievalClient implements VatRetrievalClientInterface
         ?Engine $engine = null,
         private readonly VatRatesResponseConverter $responseConverter = new VatRatesResponseConverter()
     ) {
-        $this->logger = $this->config->logger ?? new NullLogger();
+        $this->logger = $this->config->logger;
         $this->telemetry = $this->config->telemetry;
         $this->faultListener = new FaultEventListener($this->logger);
         $this->engine = $engine ?? $this->initializeEngine();
@@ -187,7 +186,6 @@ class SoapVatRetrievalClient implements VatRetrievalClientInterface
     private function performRequest(VatRatesRequest $request): VatRatesResponse
     {
         try {
-            /** @var \stdClass $responseObject */
             $responseObject = $this->engine->request('retrieveVatRates', [$request]);
 
             // Convert stdClass response to strongly-typed DTO using dedicated converter

--- a/src/DTO/Request/VatRatesRequest.php
+++ b/src/DTO/Request/VatRatesRequest.php
@@ -79,7 +79,10 @@ final class VatRatesRequest
     /**
      * Validate and normalize member state codes
      *
-     * @param array<string> $memberStates
+     * The parameter is typed as mixed values because this is the boundary that
+     * turns unvalidated caller input into the documented array<string> contract.
+     *
+     * @param array<mixed> $memberStates
      * @throws ValidationException
      */
     private function validateAndNormalizeMemberStates(array $memberStates): void

--- a/src/DTO/Response/VatRate.php
+++ b/src/DTO/Response/VatRate.php
@@ -113,17 +113,6 @@ final class VatRate implements \Stringable
     }
 
     /**
-     * Get the value as a BigDecimal for precise calculations
-     *
-     * @deprecated Use getValue() instead
-     * @return BigDecimal|null The VAT rate as a BigDecimal instance, or null if no value was provided
-     */
-    public function getDecimalValue(): ?BigDecimal
-    {
-        return $this->getValue();
-    }
-
-    /**
      * Get the raw string value as received from the API
      *
      * @return string|null The VAT rate percentage as a string (e.g., "19.0"),
@@ -132,17 +121,6 @@ final class VatRate implements \Stringable
     public function getRawValue(): ?string
     {
         return $this->value;
-    }
-
-    /**
-     * Get the value as float (use with caution for calculations)
-     *
-     * @deprecated Since 1.0.0, use getValue() for precise calculations
-     * @return float|null The VAT rate as a floating-point number, or null if no value was provided
-     */
-    public function getValueAsFloat(): ?float
-    {
-        return $this->getValue()?->toFloat();
     }
 
     /**
@@ -186,7 +164,7 @@ final class VatRate implements \Stringable
     public function isParkingRate(): bool
     {
         $normalizedType = $this->getType();
-        return $normalizedType === 'PK' || $normalizedType === 'PARKING' || $normalizedType === 'PARKING_RATE';
+        return in_array($normalizedType, ['PK', 'PARKING', 'PARKING_RATE'], true);
     }
 
     /**
@@ -208,8 +186,7 @@ final class VatRate implements \Stringable
     public function isExempt(): bool
     {
         $normalizedType = $this->getType();
-        return $normalizedType === 'E' || $normalizedType === 'EXEMPT' || $normalizedType === 'EXEMPTED' ||
-               $normalizedType === 'NOT_APPLICABLE' || $normalizedType === 'OUT_OF_SCOPE';
+        return in_array($normalizedType, ['E', 'EXEMPT', 'EXEMPTED', 'NOT_APPLICABLE', 'OUT_OF_SCOPE'], true);
     }
 
     /**

--- a/src/DTO/Response/VatRatesResponse.php
+++ b/src/DTO/Response/VatRatesResponse.php
@@ -69,7 +69,7 @@ use LogicException;
  * @package Netresearch\EuVatSdk\DTO\Response
  * @author  Netresearch DTT GmbH
  * @license https://opensource.org/licenses/MIT MIT License
- * @SuppressWarnings(PHPMD.TooManyPublicMethods)
+ * @SuppressWarnings("PHPMD.TooManyPublicMethods")
  */
 final class VatRatesResponse implements Iterator, ArrayAccess, Countable
 {
@@ -185,13 +185,13 @@ final class VatRatesResponse implements Iterator, ArrayAccess, Countable
         return $this->results[$offset];
     }
 
-    /** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
+    /** @SuppressWarnings("PHPMD.UnusedFormalParameter") */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new LogicException('VatRatesResponse is immutable');
     }
 
-    /** @SuppressWarnings(PHPMD.UnusedFormalParameter) */
+    /** @SuppressWarnings("PHPMD.UnusedFormalParameter") */
     public function offsetUnset(mixed $offset): void
     {
         throw new LogicException('VatRatesResponse is immutable');

--- a/src/EventListener/FaultEventListener.php
+++ b/src/EventListener/FaultEventListener.php
@@ -93,14 +93,14 @@ final class FaultEventListener
      *
      * `Client` is the SOAP 1.1 spelling, `Sender` the SOAP 1.2 one.
      */
-    private const CLIENT_FAULT_CODES = ['client', 'sender'];
+    private const array CLIENT_FAULT_CODES = ['client', 'sender'];
 
     /**
      * SOAP faultcode local parts that place responsibility on the service
      *
      * `Server` is the SOAP 1.1 spelling, `Receiver` the SOAP 1.2 one.
      */
-    private const SERVER_FAULT_CODES = ['server', 'receiver'];
+    private const array SERVER_FAULT_CODES = ['server', 'receiver'];
 
     /**
      * SOAP envelope namespaces a fault code may legitimately be bound to
@@ -108,7 +108,7 @@ final class FaultEventListener
      * Used to reject fault codes whose local part reads like a responsibility
      * marker but belongs to an unrelated namespace.
      */
-    private const SOAP_ENVELOPE_NAMESPACES = [
+    private const array SOAP_ENVELOPE_NAMESPACES = [
         'http://schemas.xmlsoap.org/soap/envelope/', // SOAP 1.1
         'http://www.w3.org/2003/05/soap-envelope',   // SOAP 1.2
     ];
@@ -116,17 +116,17 @@ final class FaultEventListener
     /**
      * Message used when a fault carries no usable fault string
      */
-    private const NO_FAULT_STRING = 'No fault string provided';
+    private const string NO_FAULT_STRING = 'No fault string provided';
 
     /**
      * Maximum number of nested levels walked when collecting fault detail errors
      */
-    private const DETAIL_MAX_DEPTH = 10;
+    private const int DETAIL_MAX_DEPTH = 10;
 
     /**
      * Maximum number of error descriptions collected from a single fault detail
      */
-    private const DETAIL_MAX_ERRORS = 20;
+    private const int DETAIL_MAX_ERRORS = 20;
 
     /**
      * Create fault event listener with logger
@@ -351,7 +351,7 @@ final class FaultEventListener
     {
         $segments = explode(':', $faultCode);
 
-        return strtolower(trim((string) end($segments)));
+        return strtolower(trim(end($segments)));
     }
 
     /**
@@ -376,7 +376,7 @@ final class FaultEventListener
      */
     private function normaliseFaultString(?string $faultString): string
     {
-        return trim($faultString ?? '') === '' ? self::NO_FAULT_STRING : $faultString ?? '';
+        return trim($faultString ?? '') === '' ? self::NO_FAULT_STRING : $faultString;
     }
 
     /**

--- a/src/Factory/VatRetrievalClientFactory.php
+++ b/src/Factory/VatRetrievalClientFactory.php
@@ -51,7 +51,7 @@ class VatRetrievalClientFactory
     /**
      * Default connection timeout in seconds
      */
-    private const DEFAULT_TIMEOUT = 30;
+    private const int DEFAULT_TIMEOUT = 30;
 
     /**
      * Create a production-ready client with default configuration

--- a/tests/Integration/EndToEndTest.php
+++ b/tests/Integration/EndToEndTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\EuVatSdk\Tests\Integration;
 
+use Netresearch\EuVatSdk\DTO\Response\VatRateResult;
 use PHPUnit\Framework\Attributes\Group;
 use Netresearch\EuVatSdk\Exception\InvalidRequestException;
 use Netresearch\EuVatSdk\Exception\SoapFaultException;
@@ -41,7 +42,7 @@ class EndToEndTest extends IntegrationTestCase
 
         // Step 1: Create client with default configuration
         $client = VatRetrievalClientFactory::create();
-        $this->assertNotNull($client, 'Client should be created successfully');
+        $this->assertInstanceOf(SoapVatRetrievalClient::class, $client);
 
         // Step 2: Make a simple request
         $request = new VatRatesRequest(
@@ -100,7 +101,7 @@ class EndToEndTest extends IntegrationTestCase
 
         // Test readonly properties work (PHP 8.1+)
         foreach ($response->getResults() as $result) {
-            $this->assertIsString($result->getMemberState());
+            $this->assertMatchesRegularExpression('/^[A-Z]{2}$/', $result->getMemberState());
             $this->assertInstanceOf(\DateTimeInterface::class, $result->getSituationOn());
         }
     }
@@ -138,7 +139,9 @@ class EndToEndTest extends IntegrationTestCase
             'Should receive at least one rate for each requested member state.'
         );
 
-        $returnedStates = array_unique(array_map(fn($result): string => $result->getMemberState(), $results));
+        $returnedStates = array_unique(
+            array_map(fn(VatRateResult $result): string => $result->getMemberState(), $results)
+        );
         $this->assertEmpty(
             array_diff($euMembers, $returnedStates),
             'All requested EU member states should be present in the response.'
@@ -211,7 +214,7 @@ class EndToEndTest extends IntegrationTestCase
             $client->retrieveVatRates($request);
             $this->fail('Should throw exception for empty states');
         } catch (VatServiceException) {
-            $this->assertTrue(true);
+            $this->addToAssertionCount(1);
         }
 
         // Test 3: Configuration errors
@@ -224,7 +227,7 @@ class EndToEndTest extends IntegrationTestCase
             $invalidClient->retrieveVatRates($request);
             $this->fail('Should throw ConfigurationException');
         } catch (ConfigurationException) {
-            $this->assertTrue(true);
+            $this->addToAssertionCount(1);
         }
     }
 
@@ -244,7 +247,7 @@ class EndToEndTest extends IntegrationTestCase
             $vatRate = $result->getRate();
 
             // Test precise decimal handling
-            $decimalValue = $vatRate->getDecimalValue();
+            $decimalValue = $vatRate->getValue();
             $this->assertInstanceOf(BigDecimal::class, $decimalValue);
 
             // Test financial calculations
@@ -423,9 +426,9 @@ class EndToEndTest extends IntegrationTestCase
         );
 
         try {
-            $response = $client->retrieveVatRates($oldRequest);
+            $client->retrieveVatRates($oldRequest);
             // Service might return data or error for very old dates
-            $this->assertNotNull($response);
+            $this->addToAssertionCount(1);
         } catch (VatServiceException) {
         }
 
@@ -434,7 +437,7 @@ class EndToEndTest extends IntegrationTestCase
             new VatRatesRequest(['D', 'F'], new DateTime('2024-01-01'));
             $this->fail('Should reject single character country codes');
         } catch (\Exception) {
-            $this->assertTrue(true);
+            $this->addToAssertionCount(1);
         }
 
         // Test 3: Mixed case country codes (should be normalized)
@@ -447,7 +450,7 @@ class EndToEndTest extends IntegrationTestCase
 
         // Verify normalization worked
         $countries = array_map(
-            fn($r): string => $r->getMemberState(),
+            fn(VatRateResult $r): string => $r->getMemberState(),
             $response->getResults()
         );
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -81,7 +81,7 @@ abstract class IntegrationTestCase extends TestCase
 
         if ($useProductionEndpoint) {
             // Create sandbox client but with production endpoint for testing
-            $config = ClientConfiguration::test(null)
+            $config = ClientConfiguration::test()
                 ->withEndpoint(ClientConfiguration::ENDPOINT_PRODUCTION)
                 ->withTimeout(15)
                 ->withDebug(true);
@@ -207,7 +207,7 @@ abstract class IntegrationTestCase extends TestCase
     protected function getDefaultCassetteName(): string
     {
         // Simple fallback - use class name and timestamp
-        $className = (new \ReflectionClass($this))->getShortName();
+        $className = new \ReflectionClass($this)->getShortName();
         $className = str_replace('Test', '', $className);
 
         return strtolower($className) . '/default_test_' . time();

--- a/tests/Integration/ServiceInteractionTest.php
+++ b/tests/Integration/ServiceInteractionTest.php
@@ -39,7 +39,7 @@ class ServiceInteractionTest extends IntegrationTestCase
     /**
      * The date recorded in every cassette this class replays
      */
-    private const SITUATION_ON = '2024-01-01';
+    private const string SITUATION_ON = '2024-01-01';
 
     /**
      * Member states recorded in the vat-rates-all-eu-members cassette
@@ -48,7 +48,7 @@ class ServiceInteractionTest extends IntegrationTestCase
      *
      * @var array<string>
      */
-    private const ALL_MEMBER_STATES = [
+    private const array ALL_MEMBER_STATES = [
         'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'EL', 'HU', 'IE',
         'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
     ];
@@ -56,7 +56,7 @@ class ServiceInteractionTest extends IntegrationTestCase
     /**
      * Rows in the vat-rates-all-eu-members cassette
      */
-    private const ALL_MEMBER_RESULT_COUNT = 1128;
+    private const int ALL_MEMBER_RESULT_COUNT = 1128;
 
     /**
      * Number of SOAP interactions VCR answered from a cassette
@@ -190,7 +190,7 @@ class ServiceInteractionTest extends IntegrationTestCase
     {
         // Read the parent through reflection: in the source AbusedClient extends
         // \SoapClient, and only the rewritten copy VCR loads extends VcrSoapClient.
-        $parent = (new \ReflectionClass(AbusedClient::class))->getParentClass();
+        $parent = new \ReflectionClass(AbusedClient::class)->getParentClass();
 
         $this->assertNotFalse($parent, 'The SOAP transport must extend a client class');
         $this->assertSame(

--- a/tests/Integration/VatRateErrorHandlingTest.php
+++ b/tests/Integration/VatRateErrorHandlingTest.php
@@ -193,7 +193,7 @@ class VatRateErrorHandlingTest extends IntegrationTestCase
             $client->retrieveVatRates($request);
 
             // If request completes within timeout, that's OK
-            $this->assertTrue(true);
+            $this->addToAssertionCount(1);
         } catch (ServiceUnavailableException $e) {
             // Timeout should be wrapped in ServiceUnavailableException
             $this->assertStringContainsString('Network error', $e->getMessage());

--- a/tests/Integration/VatRateRetrievalTest.php
+++ b/tests/Integration/VatRateRetrievalTest.php
@@ -168,7 +168,7 @@ class VatRateRetrievalTest extends IntegrationTestCase
 
         // Verify all countries are present (multiple results per country)
         $returnedCountries = array_values(array_unique(array_map(
-            fn($result): string => $result->getMemberState(),
+            fn(VatRateResult $result): string => $result->getMemberState(),
             $response->getResults()
         )));
 
@@ -181,7 +181,7 @@ class VatRateRetrievalTest extends IntegrationTestCase
         foreach ($euMemberStates as $memberState) {
             $standardResult = $this->findStandardRateResult($response->getResults(), $memberState);
             $this->assertNotNull($standardResult, "Should find standard VAT rate for {$memberState}");
-            $decimalValue = $standardResult->getRate()->getDecimalValue();
+            $decimalValue = $standardResult->getRate()->getValue();
             $this->assertNotNull($decimalValue);
             $this->assertGreaterThan(0, $decimalValue->toFloat());
             $this->assertLessThanOrEqual(27, $decimalValue->toFloat()); // Hungary has 27%

--- a/tests/Unit/Client/ClientConfigurationTest.php
+++ b/tests/Unit/Client/ClientConfigurationTest.php
@@ -41,7 +41,7 @@ class ClientConfigurationTest extends TestCase
 
     public function testProductionWithCustomLogger(): void
     {
-        $logger = $this->createMock(LoggerInterface::class);
+        $logger = $this->createStub(LoggerInterface::class);
         $config = ClientConfiguration::production($logger);
 
         $this->assertSame($logger, $config->logger);
@@ -82,7 +82,7 @@ class ClientConfigurationTest extends TestCase
     public function testWithLoggerImmutability(): void
     {
         $original = ClientConfiguration::production();
-        $testLogger = $this->createMock(LoggerInterface::class);
+        $testLogger = $this->createStub(LoggerInterface::class);
         $modified = $original->withLogger($testLogger);
 
         // Original should be unchanged
@@ -133,7 +133,7 @@ class ClientConfigurationTest extends TestCase
 
     public function testChainedWithMethods(): void
     {
-        $logger = $this->createMock(LoggerInterface::class);
+        $logger = $this->createStub(LoggerInterface::class);
         $telemetry = new NullTelemetry();
 
         $config = ClientConfiguration::production()
@@ -156,7 +156,6 @@ class ClientConfigurationTest extends TestCase
         // Use reflection to test private constructor with invalid endpoint
         $reflection = new \ReflectionClass(ClientConfiguration::class);
         $constructor = $reflection->getConstructor();
-        $constructor->setAccessible(true);
 
         $constructor->invoke(
             $reflection->newInstanceWithoutConstructor(),

--- a/tests/Unit/Client/ExplodingTelemetry.php
+++ b/tests/Unit/Client/ExplodingTelemetry.php
@@ -13,7 +13,7 @@ use Netresearch\EuVatSdk\Telemetry\TelemetryInterface;
  */
 final class ExplodingTelemetry implements TelemetryInterface
 {
-    public const MESSAGE = 'metrics backend is down';
+    public const string MESSAGE = 'metrics backend is down';
 
     /**
      * @param string               $operation Ignored

--- a/tests/Unit/Client/SoapHydrationTest.php
+++ b/tests/Unit/Client/SoapHydrationTest.php
@@ -36,7 +36,7 @@ class SoapHydrationTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
         $this->config = ClientConfiguration::test($this->logger);
     }
 
@@ -86,12 +86,15 @@ class SoapHydrationTest extends TestCase
         // Attempt to instantiate VatRatesResponse the way ClassMap would
         try {
             // ClassMap instantiation - creates object without calling constructor
-            $response = (new \ReflectionClass(VatRatesResponse::class))->newInstanceWithoutConstructor();
+            $response = new \ReflectionClass(VatRatesResponse::class)->newInstanceWithoutConstructor();
 
             // This will fail because $results property is not initialized
-            $response->getResults();
+            $results = $response->getResults();
 
-            $this->fail('Expected error when accessing uninitialized readonly property');
+            $this->fail(sprintf(
+                'Expected error when accessing uninitialized readonly property, got %d results',
+                count($results)
+            ));
         } catch (\Error $e) {
             $this->assertStringContainsString('must not be accessed before initialization', $e->getMessage());
             // This proves why ClassMap can't work with current DTO design
@@ -99,16 +102,19 @@ class SoapHydrationTest extends TestCase
 
         // Same issue with VatRateResult
         try {
-            $result = (new \ReflectionClass(VatRateResult::class))->newInstanceWithoutConstructor();
-            $result->getMemberState();
+            $result = new \ReflectionClass(VatRateResult::class)->newInstanceWithoutConstructor();
+            $memberState = $result->getMemberState();
 
-            $this->fail('Expected error when accessing uninitialized property');
+            $this->fail(sprintf(
+                'Expected error when accessing uninitialized property, got "%s"',
+                $memberState
+            ));
         } catch (\Error $e) {
             $this->assertStringContainsString('must not be accessed before initialization', $e->getMessage());
         }
 
         // VatRate works because it uses lazy initialization
-        $rate = (new \ReflectionClass(VatRate::class))->newInstanceWithoutConstructor();
+        $rate = new \ReflectionClass(VatRate::class)->newInstanceWithoutConstructor();
         $reflection = new \ReflectionProperty(VatRate::class, 'type');
         $reflection->setValue($rate, 'STANDARD');
         $reflection = new \ReflectionProperty(VatRate::class, 'value');

--- a/tests/Unit/Client/SoapVatRetrievalClientTest.php
+++ b/tests/Unit/Client/SoapVatRetrievalClientTest.php
@@ -31,31 +31,31 @@ class SoapVatRetrievalClientTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
         $this->config = ClientConfiguration::test($this->logger)
             ->withTimeout(30);
     }
 
     public function testImplementsVatRetrievalClientInterface(): void
     {
-        $mockEngine = $this->createMock(Engine::class);
-        $client = new SoapVatRetrievalClient($this->config, $mockEngine);
+        $engineStub = $this->createStub(Engine::class);
+        $client = new SoapVatRetrievalClient($this->config, $engineStub);
 
         $this->assertInstanceOf(VatRetrievalClientInterface::class, $client);
     }
 
     public function testConstructorInitializesEngine(): void
     {
-        $mockEngine = $this->createMock(Engine::class);
-        $client = new SoapVatRetrievalClient($this->config, $mockEngine);
+        $engineStub = $this->createStub(Engine::class);
+        $client = new SoapVatRetrievalClient($this->config, $engineStub);
 
         $this->assertInstanceOf(Engine::class, $client->getEngine());
     }
 
     public function testGetConfigurationReturnsCorrectConfig(): void
     {
-        $mockEngine = $this->createMock(Engine::class);
-        $client = new SoapVatRetrievalClient($this->config, $mockEngine);
+        $engineStub = $this->createStub(Engine::class);
+        $client = new SoapVatRetrievalClient($this->config, $engineStub);
 
         $this->assertSame($this->config, $client->getConfiguration());
     }
@@ -304,10 +304,10 @@ class SoapVatRetrievalClientTest extends TestCase
         $debugConfig = ClientConfiguration::test($this->logger)
             ->withDebug(true);
 
-        $mockEngine = $this->createMock(Engine::class);
+        $engineStub = $this->createStub(Engine::class);
 
         // This test verifies that the client initializes successfully with debug mode
-        $client = new SoapVatRetrievalClient($debugConfig, $mockEngine);
+        $client = new SoapVatRetrievalClient($debugConfig, $engineStub);
 
         $this->assertInstanceOf(SoapVatRetrievalClient::class, $client);
     }
@@ -316,8 +316,8 @@ class SoapVatRetrievalClientTest extends TestCase
     {
         $productionConfig = ClientConfiguration::production($this->logger);
 
-        $mockEngine = $this->createMock(Engine::class);
-        $client = new SoapVatRetrievalClient($productionConfig, $mockEngine);
+        $engineStub = $this->createStub(Engine::class);
+        $client = new SoapVatRetrievalClient($productionConfig, $engineStub);
 
         $this->assertInstanceOf(SoapVatRetrievalClient::class, $client);
     }
@@ -334,8 +334,8 @@ class SoapVatRetrievalClientTest extends TestCase
             ->withSoapOptions($customOptions)
             ->withTimeout(60);
 
-        $mockEngine = $this->createMock(Engine::class);
-        $client = new SoapVatRetrievalClient($config, $mockEngine);
+        $engineStub = $this->createStub(Engine::class);
+        $client = new SoapVatRetrievalClient($config, $engineStub);
 
         $this->assertInstanceOf(SoapVatRetrievalClient::class, $client);
     }

--- a/tests/Unit/Client/TelemetryIntegrationTest.php
+++ b/tests/Unit/Client/TelemetryIntegrationTest.php
@@ -31,7 +31,7 @@ class TelemetryIntegrationTest extends TestCase
     /**
      * Wall-clock time the faked SOAP call is made to consume, in microseconds
      */
-    private const SIMULATED_CALL_MICROSECONDS = 50000;
+    private const int SIMULATED_CALL_MICROSECONDS = 50000;
 
     private RecordingTelemetry $telemetry;
 

--- a/tests/Unit/Converter/VatRatesResponseConverterTest.php
+++ b/tests/Unit/Converter/VatRatesResponseConverterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netresearch\EuVatSdk\Tests\Unit\Converter;
 
+use Netresearch\EuVatSdk\DTO\Response\VatRateResult;
 use Brick\Math\BigDecimal;
 use DateTimeImmutable;
 use Netresearch\EuVatSdk\Converter\VatRatesResponseConverter;
@@ -121,7 +122,7 @@ class VatRatesResponseConverterTest extends TestCase
 
         $this->assertCount(3, $results);
         $this->assertSame(['DE', 'FR', 'NL'], array_map(
-            static fn($result): string => $result->getMemberState(),
+            static fn(VatRateResult $result): string => $result->getMemberState(),
             $results
         ));
         $this->assertSame('19.0', $results[0]->getRate()->getRawValue());
@@ -242,7 +243,7 @@ class VatRatesResponseConverterTest extends TestCase
 
         $this->assertCount(3, $converted->getResults());
         $this->assertSame(['FOODSTUFFS', null, 'ACCOMMODATION'], array_map(
-            static fn($result): ?string => $result->getCategory(),
+            static fn(VatRateResult $result): ?string => $result->getCategory(),
             $converted->getResults()
         ));
 

--- a/tests/Unit/DTO/Response/VatRateTest.php
+++ b/tests/Unit/DTO/Response/VatRateTest.php
@@ -20,9 +20,8 @@ class VatRateTest extends TestCase
 
         $this->assertEquals('STANDARD', $rate->getType());
         $this->assertEquals('19.0', $rate->getValue());
-        $this->assertInstanceOf(BigDecimal::class, $rate->getDecimalValue());
-        $this->assertEquals('19.0', $rate->getDecimalValue()->__toString());
-        $this->assertEquals(19.0, $rate->getValueAsFloat());
+        $this->assertInstanceOf(BigDecimal::class, $rate->getValue());
+        $this->assertEquals('19.0', $rate->getValue()->__toString());
 
         $this->assertTrue($rate->isStandard());
         $this->assertFalse($rate->isReduced());
@@ -131,9 +130,7 @@ class VatRateTest extends TestCase
 
         $this->assertTrue($rate->isExempt());
         $this->assertNull($rate->getValue());
-        $this->assertNull($rate->getDecimalValue());
         $this->assertNull($rate->getRawValue());
-        $this->assertNull($rate->getValueAsFloat());
         $this->assertEquals('', (string) $rate);
     }
 
@@ -163,9 +160,8 @@ class VatRateTest extends TestCase
     {
         $rate = new VatRate('STANDARD', '19.75');
 
-        $decimalValue = $rate->getDecimalValue();
+        $decimalValue = $rate->getValue();
         $this->assertInstanceOf(BigDecimal::class, $decimalValue);
-        $this->assertEquals('19.75', $rate->getValue());
         $this->assertEquals('19.75', $decimalValue->__toString());
 
         // Test calculation precision

--- a/tests/Unit/DTO/Response/VatRatesResponseTest.php
+++ b/tests/Unit/DTO/Response/VatRatesResponseTest.php
@@ -62,7 +62,6 @@ class VatRatesResponseTest extends TestCase
         $results = $this->response->getResultsForCountry('XX');
 
         $this->assertCount(0, $results);
-        $this->assertIsArray($results);
     }
 
     public function testGetResultsByCategory(): void
@@ -96,14 +95,13 @@ class VatRatesResponseTest extends TestCase
         $results = $this->response->getResultsByCategory('NONEXISTENT');
 
         $this->assertCount(0, $results);
-        $this->assertIsArray($results);
     }
 
     public function testIteratorInterface(): void
     {
         $count = 0;
         foreach ($this->response as $key => $result) {
-            $this->assertIsInt($key);
+            $this->assertSame($count, $key, 'Iterator keys must be sequential');
             $this->assertInstanceOf(VatRateResult::class, $result);
             $count++;
         }

--- a/tests/Unit/EventListener/FaultEventListenerTest.php
+++ b/tests/Unit/EventListener/FaultEventListenerTest.php
@@ -34,14 +34,14 @@ class FaultEventListenerTest extends TestCase
     /**
      * Fault string exactly as recorded from the service
      */
-    private const REAL_FAULT_STRING = 'TEDB-ERR-2 - Request is not valid';
+    private const string REAL_FAULT_STRING = 'TEDB-ERR-2 - Request is not valid';
 
     private LoggerInterface $logger;
     private FaultEventListener $listener;
 
     protected function setUp(): void
     {
-        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
         $this->listener = new FaultEventListener($this->logger);
     }
 
@@ -85,16 +85,18 @@ class FaultEventListenerTest extends TestCase
     {
         $fault = $this->createRealClientFault();
 
-        $this->logger->expects($this->once())
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
             ->method('error')
             ->with(
                 'SOAP Fault received from EU VAT service',
                 $this->callback(fn($context): bool => $context['fault_code'] === 'env:Client'
                     && $context['fault_string'] === self::REAL_FAULT_STRING)
             );
+        $listener = new FaultEventListener($logger);
 
         try {
-            $this->listener->handleSoapFault($fault);
+            $listener->handleSoapFault($fault);
             $this->fail('Expected InvalidRequestException');
         } catch (InvalidRequestException $e) {
             $this->assertSame('TEDB-ERR-2', $e->getErrorCode());
@@ -374,16 +376,18 @@ class FaultEventListenerTest extends TestCase
         $fault = $this->createRealClientFault();
         $detail = $fault->detail;
 
-        $this->logger->expects($this->once())
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
             ->method('error')
             ->with(
                 'SOAP Fault received from EU VAT service',
                 $this->callback(fn($context): bool => $context['fault_detail'] === $detail)
             );
+        $listener = new FaultEventListener($logger);
 
         $this->expectException(InvalidRequestException::class);
 
-        $this->listener->handleSoapFault($fault);
+        $listener->handleSoapFault($fault);
     }
 
     /**

--- a/tests/Unit/Factory/VatRetrievalClientFactoryTest.php
+++ b/tests/Unit/Factory/VatRetrievalClientFactoryTest.php
@@ -22,8 +22,8 @@ class VatRetrievalClientFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->logger = $this->createMock(LoggerInterface::class);
-        $this->telemetry = $this->createMock(TelemetryInterface::class);
+        $this->logger = $this->createStub(LoggerInterface::class);
+        $this->telemetry = $this->createStub(TelemetryInterface::class);
     }
 
     public function testCreateReturnsDefaultClient(): void

--- a/tests/Unit/Telemetry/NullTelemetryTest.php
+++ b/tests/Unit/Telemetry/NullTelemetryTest.php
@@ -81,7 +81,7 @@ class NullTelemetryTest extends TestCase
                 'result_count' => 2,
             ]);
 
-            $this->assertTrue(true); // Test passed if no exceptions
+            $this->addToAssertionCount(1); // Test passed if no exceptions
         } catch (\Exception $e) {
             $telemetry->recordError('retrieveVatRates', $e::class, [
                 'error_message' => $e->getMessage(),

--- a/tests/Unit/TypeConverter/BigDecimalTypeConverterTest.php
+++ b/tests/Unit/TypeConverter/BigDecimalTypeConverterTest.php
@@ -251,7 +251,7 @@ class BigDecimalTypeConverterTest extends TestCase
             'typemap' => [[
                 'type_ns' => $converter->getTypeNamespace(),
                 'type_name' => $converter->getTypeName(),
-                'from_xml' => static fn (string $xml): ?BigDecimal => $converter->convertXmlToPhp($xml),
+                'from_xml' => $converter->convertXmlToPhp(...),
             ]],
             'location' => 'http://localhost/unused',
         ]) extends \SoapClient {
@@ -267,7 +267,7 @@ class BigDecimalTypeConverterTest extends TestCase
                 int $version,
                 bool $oneWay = false,
                 ?string $uriParserClass = null
-            ): ?string {
+            ): string {
                 return $this->recordedResponse;
             }
         };

--- a/tests/Unit/TypeConverter/DateTypeConverterTest.php
+++ b/tests/Unit/TypeConverter/DateTypeConverterTest.php
@@ -104,7 +104,7 @@ class DateTypeConverterTest extends TestCase
             'typemap' => [[
                 'type_ns' => $converter->getTypeNamespace(),
                 'type_name' => $converter->getTypeName(),
-                'to_xml' => static fn ($php): string => $converter->convertPhpToXml($php),
+                'to_xml' => $converter->convertPhpToXml(...),
             ]],
             'location' => 'http://localhost/unused',
         ]) extends \SoapClient {
@@ -120,7 +120,7 @@ class DateTypeConverterTest extends TestCase
                 int $version,
                 bool $oneWay = false,
                 ?string $uriParserClass = null
-            ): ?string {
+            ): string {
                 $this->capturedRequest = $request;
                 return '';
             }

--- a/tests/security-review.php
+++ b/tests/security-review.php
@@ -45,7 +45,6 @@ foreach ($sqlInjectionTests as $test) {
         // If we get here, check if the values were sanitized
         $reflection = new ReflectionObject($request);
         $prop = $reflection->getProperty('memberStates');
-        $prop->setAccessible(true);
         $values = $prop->getValue($request);
 
         // Check if dangerous input was properly handled
@@ -114,7 +113,7 @@ foreach ($errorScenarios as $scenario) {
             new VatRatesRequest(['DE'], new \DateTime($scenario['date']));
         } else {
             $request = new VatRatesRequest(
-                $scenario['countries'] ?? ['DE'],
+                $scenario['countries'],
                 new \DateTime('2024-01-01')
             );
             $client->retrieveVatRates($request);
@@ -197,7 +196,6 @@ try {
 $defaultConfig = ClientConfiguration::production();
 $reflection = new ReflectionObject($defaultConfig);
 $timeoutProp = $reflection->getProperty('timeout');
-$timeoutProp->setAccessible(true);
 $timeout = $timeoutProp->getValue($defaultConfig);
 
 if ($timeout > 300) {


### PR DESCRIPTION
Phase 2 of the dependency plan. v3.0.0 was the last PHP 8.2 release; this raises the floor to `^8.4` and lands everything that floor was holding back, as a single new major.

Closes #6
Closes #9

## Why the floor had to move

`php-soap/ext-soap-engine` is the pivot. 1.8.0 requires PHP 8.3+, 1.12.0 requires `~8.4.0 || ~8.5.0`, so 1.7.0 was the only release installable on 8.2. Its `AbusedClient::__doRequest()` lacks the `$uriParserClass` parameter that php-vcr 1.8.2+ needs — which is what capped `php-vcr` at `<1.8.2`. The two constraints move together or not at all.

## Why #6 and #9 land here rather than on their own

`phpstan/phpstan ^2` and `rector/rector ^2` are a mirror-image deadlock: Rector 1.x requires `phpstan ^1.x`, Rector 2.x requires `^2.x`. Neither PR could ever go green alone. Bumped together they resolve cleanly (phpstan 2.2.7 + rector 2.5.9). With Rector on 2.x the level set moves to `UP_TO_PHP_84`, which is the payoff for pairing the tooling bump with the floor raise.

## Breaking changes for consumers

| Change | Impact |
|---|---|
| `php: ^8.2` → `^8.4` | Consumers below 8.4 cannot install |
| `php-soap/ext-soap-engine: ^1.7` → `^1.12` | Runtime dependency; consumers pinned below 1.12 cannot install |
| `VatRate::getDecimalValue()` removed | Plain alias of `getValue()`; replace one-for-one |
| `VatRate::getValueAsFloat()` removed | No direct replacement by design. `getValue()` is nullable, so the equivalent is `$rate->getValue()?->toFloat()` — the removed method used the null-safe operator too |

Both removed methods were tagged `@deprecated` since 1.0.0. Rector's PHP 8.4 set wanted to convert them to `#[\Deprecated]`, but a library that raises `E_USER_DEPRECATED` on a public getter floods consumer logs it does not control, so they are removed instead.

## What PHPStan 2 surfaced in `src/`

Four pieces of dead defensive code. The notable one: `SoapVatRetrievalClient::performRequest()` guarded its response with `instanceof \stdClass`, but a `/** @var \stdClass */` annotation directly above asserted the type, making the check unconditionally true. The annotation is removed and the guard is kept, so it now does what it was written to do.

Ten of the fifteen `ignoreErrors` patterns in `phpstan.neon` no longer matched anything and were removed — among them a blanket `If condition is always true.` that would have masked real findings.

## Not included

- `symfony/event-dispatcher` v8 (#10) stays permanently inapplicable: php-vcr caps event-dispatcher at `^7` at every release
- `brick/math ^0.19` (#2) was never blocked by the 8.2 floor and is out of scope here

## Verification

CI runs 8.4 and 8.5. Locally, resolution and all four gates were verified against a composer platform pinned to **8.4.1** — the first PHP 8.4 release that shipped as GA, and the lowest on which the dev toolchain installs (PHPUnit 13 requires `>=8.4.1`). The pinned run installed an identical dependency set to the unpinned one.

- `phpunit --testsuite=unit` — 191 tests, 593 assertions, no notices
- `phpunit --testsuite=integration` — 12 tests, 1085 assertions
- `phpunit --group network` — 13 tests, 292 assertions (1 pre-existing `markTestIncomplete`)
- `phpstan analyse` / `phpcs` / `phpmd` / `rector --dry-run` — all clean
