### PR TITLE
fix(deps): repair the dev-dependency floors and test them in CI

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -45,6 +45,26 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  tests-lowest:
+    name: Tests (lowest deps)
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.4"]'
+      extensions: "soap, libxml, mbstring"
+      coverage: "none"
+      run-phpstan: false
+      # Resolves every constraint to its floor instead of its ceiling. Without
+      # this leg a lower bound is a claim rather than a tested fact: there is no
+      # lockfile, so the normal run always installs the newest set and can never
+      # exercise the oldest one. That is how `php-vcr >=1.6.4` and
+      # `symfony/event-dispatcher ^6.0` sat here declared-but-broken -- at their
+      # floors both emit PHP 8.4 implicit-nullable deprecations that ext-soap
+      # turns into a failed SOAP call.
+      dependency-versions: "lowest"
+      phpunit-cmd: 'vendor/bin/phpunit --testsuite=unit --no-coverage && USE_PRODUCTION_ENDPOINT=false REFRESH_CASSETTES=false vendor/bin/phpunit --testsuite=integration --no-coverage && USE_PRODUCTION_ENDPOINT=false REFRESH_CASSETTES=false vendor/bin/phpunit --group network --no-coverage'
+
   security:
     name: Security Scan
     uses: netresearch/.github/.github/workflows/php-ci.yml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `brick/math` accepts `^0.18 || ^0.19`, where only `^0.18` was previously accepted.
+  0.19.0 is purely additive — a `RoundingMode::HalfOdd` case and
+  `RoundingMode::fromNativeRoundingMode()`. The range is widened rather than moved,
+  because `BigDecimal` is public API here via `VatRate::getValue()`, and for a `0.x`
+  package `^0.18` and `^0.19` are mutually exclusive: replacing the constraint would
+  lock out consumers pinned to 0.18 for no gain
+
+### Fixed
+
+- Three dev-dependency lower bounds were declared but broken on PHP 8.4, and are raised
+  to versions that actually work: `php-vcr/php-vcr` to `>=1.8.1` (1.6.4 declares a bare
+  `php: ^8` and predates 8.4 support), `symfony/event-dispatcher` to `^6.4.8 || ^7.1`
+  (6.4.7 and below, and 7.0.x, declare `hasListeners(string $eventName = null)`), and a
+  direct `symfony/event-dispatcher-contracts: ^3.5` requirement (3.4 and below, including
+  the 2.5 that every event-dispatcher release still admits, declare
+  `dispatch(object $event, string $eventName = null)`). At their old floors all three
+  emit PHP 8.4 implicit-nullable deprecations, which ext-soap converts into a
+  `ServiceUnavailableException` — a failed SOAP call, not a warning. Consumers were never
+  affected: all three are `require-dev`
+
+### Added
+
+- A `Tests (lowest deps)` CI job resolving every constraint to its floor
+  (`dependency-versions: lowest`). There is no lockfile, so the normal run always
+  installs the newest set and could never exercise the oldest one — which is how the
+  bounds above stayed broken while CI was green
+
 ## [4.0.0] - 2026-07-31
 
 The PHP 8.4 major. It raises the floor to `^8.4` and lands every update that the 8.2

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.4",
         "ext-libxml": "*",
         "ext-soap": "*",
-        "brick/math": "^0.18",
+        "brick/math": "^0.18 || ^0.19",
         "php-soap/ext-soap-engine": "^1.12",
         "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
@@ -32,9 +32,10 @@
         "squizlabs/php_codesniffer": "^4.0",
         "slevomat/coding-standard": "^8.0",
         "rector/rector": "^2.5",
-        "php-vcr/php-vcr": ">=1.6.4 <1.12",
+        "php-vcr/php-vcr": ">=1.8.1 <1.12",
         "phpmd/phpmd": "^2.13",
-        "symfony/event-dispatcher": "^6.0 || ^7.0"
+        "symfony/event-dispatcher": "^6.4.8 || ^7.1",
+        "symfony/event-dispatcher-contracts": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Supersedes #2.

## The bug

Three dev-dependency lower bounds were declared but broken on PHP 8.4. `composer update --prefer-lowest` reproduces it:

```
symfony/event-dispatcher-contracts 2.5.0  dispatch(object $event, string $eventName = null)
symfony/event-dispatcher 6.0.0            hasListeners(string $eventName = null)
php-vcr/php-vcr 1.6.4                     bare `php: ^8`, predates 8.4 support
```

On PHP 8.4 each raises an implicit-nullable deprecation. ext-soap converts it into a `RequestException`, which the client maps to `ServiceUnavailableException` — so the integration and network suites **error**, they do not merely warn:

```
EndToEndTest::testCompleteWorkflowFromInstallationToApiCall
ServiceUnavailableException: Network error occurred while connecting to EU VAT service:
Internal ext-soap error: …::dispatch(): Implicitly marking parameter $eventName as
nullable is deprecated, the explicit nullable type must be used instead
```

**No consumer is affected** — all three are `require-dev`. v4.0.0 is not defective in what it ships.

## Why CI never caught it

`config.lock` is `false`, so there is no lockfile. Every CI run and every local install resolves each constraint to its *ceiling*. Nothing has ever installed the floor, so a lower bound here has always been an assertion rather than a tested fact.

## Fixes

| Constraint | Before | After | Reason |
|---|---|---|---|
| `php-vcr/php-vcr` | `>=1.6.4 <1.12` | `>=1.8.1 <1.12` | 1.6.4–1.8.0 either cap PHP below 8.4 or predate 8.4 support |
| `symfony/event-dispatcher` | `^6.0 \|\| ^7.0` | `^6.4.8 \|\| ^7.1` | 6.4.7 and below, and all 7.0.x, use implicit nullables |
| `symfony/event-dispatcher-contracts` | *(transitive)* | `^3.5` | every event-dispatcher release still admits contracts 2.5, which is dirty; 3.5.0 is the first with `?string` |

Plus a `Tests (lowest deps)` job (`dependency-versions: lowest`, already supported by the shared `php-ci.yml`) running all three suites at the floor, so this cannot rot again.

## brick/math, superseding #2

#2 replaced `^0.18` with `^0.19`. 0.19.0 is purely additive — a `RoundingMode::HalfOdd` case and `RoundingMode::fromNativeRoundingMode()`, neither used here. But `BigDecimal` is public API via `VatRate::getValue()`, and for a `0.x` package `^0.18` and `^0.19` are mutually exclusive, so *replacing* the constraint locks out consumers pinned to 0.18 and would force a v5.0.0 one day after v4.0.0. Widened to `^0.18 || ^0.19` instead, which ships as a minor.

## Verification

Locally, both ends of every range, all three suites plus phpstan/phpcs/phpmd/rector:

- **lowest** — brick/math 0.18.0, php-vcr 1.8.1, event-dispatcher 6.4.8, contracts 3.5.0, psr/log 1.0.1, monolog 2.10.0 → unit 191, integration 12, network 13, all green
- **highest** — brick/math 0.19.0, php-vcr 1.11.2, event-dispatcher 7.4.15, contracts 3.7.1 → same, all green